### PR TITLE
Rooms Schema Bug Fix

### DIFF
--- a/api/app/schemas/bookings/room_schema.py
+++ b/api/app/schemas/bookings/room_schema.py
@@ -23,6 +23,7 @@ class RoomSchema(ma.ModelSchema):
 
     class Meta:
         model = Room
+        exclude = ("booking",)
         jit = toastedmarshmallow.Jit
 
     capacity = fields.Int()


### PR DESCRIPTION
Excluded the "booking" object from the room schema such that an array of booking ids was not returned when the GET rooms method was called.