### PR TITLE
Exam Returned Ind Default Value

### DIFF
--- a/api/app/models/bookings/exam.py
+++ b/api/app/models/bookings/exam.py
@@ -33,7 +33,7 @@ class Exam(Base):
     number_of_students = db.Column(db.Integer, nullable=True)
     exam_method = db.Column(db.String(15), nullable=False)
     deleted_date = db.Column(db.String(50), nullable=True)
-    exam_returned_ind = db.Column(db.Integer, nullable=False)
+    exam_returned_ind = db.Column(db.Integer, nullable=False, default=0)
     exam_returned_tracking_number = db.Column(db.String(50), nullable=True)
 
     booking = db.relationship("Booking")


### PR DESCRIPTION
During testing, it was found out that the exam_returned_ind field on the exam table was set to nullable=false. When a new exam was created, this field was not attached to the POST method, which ended up in a 422 error code. This was fixed by adding a default value of zero to the column so that the nullable property of the field was not violated, which means on creation, exams are not returned.