### PR TITLE
Link Single Exam to Booking Feature

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -380,6 +380,13 @@
         if (view.name === 'agendaDay' || view.name === 'agendaWeek') {
           this.options({ name: 'height', value: 'auto' })
         }
+        if(this.$route.params.date){
+          this.$refs.bookingcal.fireMethod('changeView', 'agendaDay')
+          this.goToDate(this.$route.params.date)
+          this.$router.push('/booking')
+        }else{
+          this.$router.push('/booking')
+        }
       },
       events() {
         if (this.searchTerm) {
@@ -395,7 +402,10 @@
 
 
 </script>
+<<<<<<< HEAD
 
 <style>
 
   </style>
+=======
+>>>>>>> f41ce7a... Link Single Exam to Booking Feature

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -37,6 +37,7 @@
                     right text="">
           <b-dropdown-item size="sm" @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
           <b-dropdown-item size="sm" @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
+          <b-dropdown-item v-if=row.item.booking size="sm" @click="updateBookingRoute(row.item, row.index)">Update Booking</b-dropdown-item>
         </b-dropdown>
       </template>
     </b-table>
@@ -49,6 +50,7 @@
   import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
   import EditExamModal from './edit-exam-form-modal'
   import ReturnExamModal from './return-exam-form-modal'
+  import moment from 'moment'
 
   export default {
     name: "ExamInventoryTable",
@@ -70,7 +72,8 @@
           {key: 'invigilator', label: 'Invigilator', sortable: true },
           {key: 'booking.room.room_name', label: 'Location', sortable: true },
           {key: 'actions', label: 'Actions', sortable: false}
-        ]
+        ],
+        bookingRouteString: '',
       }
     },
     methods: {
@@ -115,6 +118,12 @@
       returnExamInfo(item, index) {
         this.toggleReturnExamModalVisible(true)
         this.setReturnExamInfo(item)
+      },
+      updateBookingRoute(item) {
+        let bookingRoute = '/booking/'
+        let rowDate = moment(item.booking.start_time).format('YYYY-MM-DD')
+        let dateConcat = bookingRoute.concat(rowDate)
+        this.$router.push(dateConcat)
       }
     },
     mounted() {
@@ -125,7 +134,7 @@
     },
     computed: {
       ...mapGetters(['role_code', 'exam_inventory', 'calendar_events']),
-      ...mapState(['user', 'exams', 'showExamInventoryModal', 'bookings', 'showEditExamModalVisible', 'showReturnExamModalVisible' ]),
+      ...mapState(['user', 'exams', 'showExamInventoryModal', 'bookings', 'showEditExamModalVisible', 'showReturnExamModalVisible', 'calendarSetup' ]),
       selectedExams() {
         if (this.showExamInventoryModal) {
           return this.exam_inventory

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -80,7 +80,14 @@ export default new Router({
             default: Calendar,
             buttons: ButtonsCalendar,
           }
-        }
+        },
+        {
+          path: 'booking/:date',
+          components: {
+            default: Calendar,
+            buttons: ButtonsCalendar,
+          }
+        },
       ]
     },
     {


### PR DESCRIPTION
Room Bookings users require easy access to editing information with respect to a single exam. With this being said, once an exam is booked, the booking itself might need to be changed. The exam inventory table presents an easy way for users to filter through all exams, and the actions field presents a way for the user to link directly to a particular exams booking quickly. Based on logic if a booking for an exam is present, a dropdown in the actions tab will show up called "Update Booking", and once clicked, the user is taken directly to the DAY view of the booking calendar where this exam is currently booked.

Future enhancements to this may include the user being brought directly to the edit booking modal to avoid confusion.