### PR TITLE
Fix Issues With Logins

### DIFF
--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -60,6 +60,10 @@ class CsrSelf(Resource):
     def get(self):
         try:
             csr = CSR.find_by_username(g.oidc_token_info['username'])
+
+            if not csr:
+                return {'Message': 'User Not Found'}, 404
+
             db.session.add(csr)
             active_sr_state = SRState.get_state_by_name("Active")
             today = datetime.now()

--- a/api/manage.py
+++ b/api/manage.py
@@ -369,6 +369,51 @@ class Bootstrap(Command):
             deleted=None,
             csr_state_id=csr_state_logout.csr_state_id
         )
+        akroon3r = theq.CSR(
+            username="akroon3r",
+            office_id=office_test.office_id,
+            role_id=role_csr.role_id,
+            qt_xn_csr_ind=0,
+            receptionist_ind=1,
+            deleted=None,
+            csr_state_id=csr_state_logout.csr_state_id
+        )
+        sjrumsby = theq.CSR(
+            username="sjrumsby",
+            office_id=office_test.office_id,
+            role_id=role_csr.role_id,
+            qt_xn_csr_ind=0,
+            receptionist_ind=1,
+            deleted=None,
+            csr_state_id=csr_state_logout.csr_state_id
+        )
+        scottrumsby = theq.CSR(
+            username="scottrumsby",
+            office_id=office_test.office_id,
+            role_id=role_csr.role_id,
+            qt_xn_csr_ind=0,
+            receptionist_ind=1,
+            deleted=None,
+            csr_state_id=csr_state_logout.csr_state_id
+        )
+        ChrisDMac = theq.CSR(
+            username="ChrisDMac",
+            office_id=office_test.office_id,
+            role_id=role_csr.role_id,
+            qt_xn_csr_ind=0,
+            receptionist_ind=1,
+            deleted=None,
+            csr_state_id=csr_state_logout.csr_state_id
+        )
+        gil0109 = theq.CSR(
+            username="gil0109",
+            office_id=office_test.office_id,
+            role_id=role_csr.role_id,
+            qt_xn_csr_ind=0,
+            receptionist_ind=1,
+            deleted=None,
+            csr_state_id=csr_state_logout.csr_state_id
+        )
         demo_ga = theq.CSR(
             username="admin",
             office_id=office_test.office_id,
@@ -391,6 +436,11 @@ class Bootstrap(Command):
         db.session.add(cfms_postman_non_operator)
         db.session.add(demo_ga)
         db.session.add(demo_csr)
+        db.session.add(akroon3r)
+        db.session.add(sjrumsby)
+        db.session.add(scottrumsby)
+        db.session.add(ChrisDMac)
+        db.session.add(gil0109)
         db.session.commit()
 
         #-- The Office / Services values ------------------------------------

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,7 +15,7 @@ limitations under the License.*/
 <template>
   <div id="App">
     <Header />
-    <div :style="style">
+    <div v-if="user.username && isLoggedIn" :style="style">
       <Alert />
       <ExamAlert />
       <Nav v-if="isLoggedIn" />
@@ -23,7 +23,10 @@ limitations under the License.*/
       <Feedback />
       <Response />
     </div>
-      <Footer />
+    <div v-else-if="!user.username && isLoggedIn">
+      <LoginWarning />
+    </div>
+    <Footer />
   </div>
 </template>
 
@@ -37,11 +40,14 @@ limitations under the License.*/
   import Feedback from './feedback'
   import Response from './response'
   import Nav from './layout/nav'
+  import Login from "./Login";
+  import LoginWarning from './login-warning'
+
   export default {
     name: 'App',
-    components: { Nav, Alert, ExamAlert, Header, Socket, Footer, Feedback, Response },
+    components: { Login, LoginWarning, Nav, Alert, ExamAlert, Header, Socket, Footer, Feedback, Response },
     computed: {
-      ...mapState(['isLoggedIn', 'showSchedulingIndicator']),
+      ...mapState(['isLoggedIn', 'showSchedulingIndicator', 'user' ]),
       style() {
         let output = {marginTop: 72+'px', width: '100%', overflowY: 'auto'}
         if (this.showSchedulingIndicator) {

--- a/frontend/src/login-warning.vue
+++ b/frontend/src/login-warning.vue
@@ -1,0 +1,31 @@
+/*Copyright 2015 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+<template>
+  <div>
+    <b-alert
+      variant="warning"
+      dismissible
+      style="h-align: center; font-size:1rem; border-radius: 0px;">
+      Username does not exist. Please Contact an Administrator
+    </b-alert>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'LoginWarning',
+}
+</script>


### PR DESCRIPTION
When logging in, if the username does not exist in the Q System database, the call to /csrs/me will 500, leading to a poor front end experience. To clean this up, changes were made such that if the username did not exist /csrs/me returned a 404 response. The frontend had an bootstrap alert added such that if the username name did not exist BUT the user was logged in, the user would be warned saying to contact an administrator. The final step was to provisioni csr usernames in the Database for Sean, Scott, Adam, Chris and Karim for future use.