### PR TITLE
Issue with Liaison Role Creating Exams

### DIFF
--- a/api/app/resources/bookings/exam/exam_post.py
+++ b/api/app/resources/bookings/exam/exam_post.py
@@ -39,7 +39,7 @@ class ExamPost(Resource):
             logging.warning("WARNING: %s", warning)
             return {"message": warning}, 422
 
-        if exam.office_id == csr.office_id:
+        if exam.office_id == csr.office_id or csr.role_code == "LIAISON":
 
             db.session.add(exam)
             db.session.commit()

--- a/api/manage.py
+++ b/api/manage.py
@@ -91,11 +91,16 @@ class Bootstrap(Command):
             role_code="ANALYTICS",
             role_desc="Analtyics Team to update Services per Office"
         )
+        role6 = theq.Role(
+            role_code="LIAISON",
+            role_desc="Centralized Government Agent Officer responsible for liaising without outside providers (e.g., ITA)"
+        )
         db.session.add(role_csr)
         db.session.add(role_ga)
         db.session.add(role3)
         db.session.add(role4)
         db.session.add(role5)
+        db.session.add(role6)
         db.session.commit()
 
         #-- Period State ----------------------------------------------------


### PR DESCRIPTION
During development of the bookings feature, it was found out that liasons could not POST exams from one office to a different office (ie// office_id 1 -> office_id 3). Since Liaisons require the ability to create exams in all offices, a change needed to be made to the exam POST end-point, checking for the csr role code to be LIAISON. Test data was also added to the manage.py file such that the role code LIASON exists now. A normal POST of an individual ITA exam was done in order to the test that previous functionality was not changed.