### PR TITLE
Monthly Financial Reports - Backend Changes

### DIFF
--- a/api/app/resources/bookings/exam/exam_export_list.py
+++ b/api/app/resources/bookings/exam/exam_export_list.py
@@ -1,0 +1,72 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+import logging
+from flask import g, request
+from flask_restplus import Resource
+from sqlalchemy import exc
+from app.models.bookings import Exam, Booking
+from app.models.theq import CSR
+from app.schemas.bookings import ExamSchema
+from qsystem import api, oidc
+from datetime import datetime, timedelta
+import pytz
+
+
+@api.route("/exams/export/", methods=["GET"])
+class ExamList(Resource):
+
+    exam_schema = ExamSchema(many=True)
+
+    timezone = pytz.timezone("US/Pacific")
+
+    @oidc.accept_token(require_token=True)
+    def get(self):
+        try:
+            csr = CSR.find_by_username(g.oidc_token_info['username'])
+
+            start_param = request.args.get("start_date")
+            end_param = request.args.get("end_date")
+
+            if not(start_param and end_param):
+
+                return {"message": "Must provide both start and end time"}, 422
+
+            try:
+                start_date = datetime.strptime(request.args['start_date'], "%Y-%m-%d")
+                end_date = datetime.strptime(request.args['end_date'], "%Y-%m-%d")
+
+            except ValueError as err:
+                print(err)
+                return {"message", "Unable to return date time string"}, 422
+
+            start_date = self.timezone.localize(start_date)
+
+            end_date += timedelta(days=1)
+
+            end_date = self.timezone.localize(end_date)
+
+            exams = Exam.query.filter_by(office_id=csr.office_id)\
+                              .join(Booking, Exam.booking_id == Booking.booking_id)\
+                              .filter(Booking.start_time >= start_date)\
+                              .filter(Booking.start_time < end_date)
+
+            result = self.exam_schema.dump(exams)
+
+            return {'exams': result.data,
+                    'errors': result.errors}, 200
+
+        except exc.SQLAlchemyError as error:
+            logging.error(error, exc_info=True)
+            return {"message": "api is down"}, 500

--- a/api/postman/bookings-postman.json
+++ b/api/postman/bookings-postman.json
@@ -2022,6 +2022,58 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Exams Export",
+			"item": [
+				{
+					"name": "Localhost - Exams Export List",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:5000/api/v1/exams/export/?start_date=2019-01-05&end_date=2019-01-25",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "5000",
+							"path": [
+								"api",
+								"v1",
+								"exams",
+								"export",
+								""
+							],
+							"query": [
+								{
+									"key": "start_date",
+									"value": "2019-01-05"
+								},
+								{
+									"key": "end_date",
+									"value": "2019-01-25"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [
@@ -2048,7 +2100,7 @@
 	],
 	"variable": [
 		{
-			"id": "04bc42c3-7393-4b06-b728-d27d89110ef8",
+			"id": "6ed13691-69b6-4949-a613-77fdb2ac8b6b",
 			"key": "auth_variable",
 			"value": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1NXhiZzcyaml6NWQ3cEtkbzdwNFhLdTB2VFA2UXMtemthZzFaY1ZKWTZVIn0.eyJqdGkiOiJmZWVlYzU4YS0zOTY0LTQwZDgtOTk3Ni02OTg1ZjNiNmQ2NzYiLCJleHAiOjE1NDQwMzY2NzQsIm5iZiI6MCwiaWF0IjoxNTQ0MDM0ODc0LCJpc3MiOiJodHRwczovL3Nzby10ZXN0LnBhdGhmaW5kZXIuZ292LmJjLmNhL2F1dGgvcmVhbG1zL3NiYyIsImF1ZCI6ImNmbXMtREVWIiwic3ViIjoiY2ZmNTQ3MDItZTkzMC00YjZlLTlhYzgtMmZkMTRjY2FmNzUxIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiY2Ztcy1ERVYiLCJub25jZSI6ImM1Zjg1NzBmLTgwNDktNDUxNC04Mjg4LTJjN2RmMzdkZTc5NSIsImF1dGhfdGltZSI6MTU0NDAzMjgxNywic2Vzc2lvbl9zdGF0ZSI6IjM4YjhiYzY4LTdmZDktNDE0NC04YWQ1LTI4ZGRlNmMwYWE1MCIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiKiJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsidW1hX2F1dGhvcml6YXRpb24iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiQ0ZNUyBQb3N0bWFuIE9wZXJhdG9yIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiY2Ztcy1wb3N0bWFuLW9wZXJhdG9yIiwiZ2l2ZW5fbmFtZSI6IkNGTVMgUG9zdG1hbiIsImZhbWlseV9uYW1lIjoiT3BlcmF0b3IifQ.CaDq7kLDMu1oqUVm6fhiAw4ubu_D4jVdkXrqLjfCxu9b-9GzyNSIK1Gy0NCesN3caG684-Ofv3LlragMOwdoRhx-xkO6j5rqPhh2EdEDYTGkrnmQrVBjgHECLYN3RSAUWk4oKsp7gRMLDorU6QWLZNRWe9qlzulbss08Mut4nZz1RV0CirvJQ9oshBdpstQIPBM7ZEptcF2AOnc8swcFMJ3mqdrs0ImytArwZEzYwRzSIAR0-kYW-AXq-TK1dk2R7fqkMXmy3ZdHoQlFRfNtfYILVPzBAq3zPftrD-lmCcfUWz-0UcwhmNELQ-Pej-t_Z_eFSPPGkAVIuv_kkHbqQw",
 			"type": "string"

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -140,6 +140,7 @@ import app.resources.bookings.exam.exam_detail
 import app.resources.bookings.exam.exam_list
 import app.resources.bookings.exam.exam_post
 import app.resources.bookings.exam.exam_put
+import app.resources.bookings.exam.exam_export_list
 import app.resources.bookings.invigilator.invigilator_list
 import app.resources.bookings.room.room_list
 import app.resources.bookings.exam_type.exam_type_list


### PR DESCRIPTION
As a finanace member, a bookings user will require to access an ability to gerenate a report or csv file to help generate a report on monthly/yearly revenues incurred from exams. In order to do this, a new end-point was added to GET all exams based on two url parameteres (start_date and end_date). Based on these parameters, the GET looks at all exams that were booked between those dates (exam and booking model are joined, then queried). Along with this new end-point, this PR includes a new set of postman tests to ensure that this end-point returns exactly what is required in order to generate these reports.