### PR TITLE
Fixed various issues with add-group-exam workflow+filtering on exam table

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -122,7 +122,7 @@ export const SelectOffice = Vue.component('select-question', {
                         @input="filter"
                         class="mb-1"
                         placeholder="Start typing to search"/>
-            <div style="background-color: whitesmoke; border: 1px solid lightgrey">
+            <div style="border: 1px solid lightgrey">
             <b-table :items="items"
                      :fields="fields"
                      :filter="search"
@@ -131,12 +131,10 @@ export const SelectOffice = Vue.component('select-question', {
                      :per-page="3"
                      class="pb-0"
                      :id="q.key"
-                     thead-tr-class="thead-tr-class"
-                     :bordered="false"
-                     :outlined="false"
-                     :striped="false"
+                     head-variant="light"
+                     hover
                      :fixed="true"
-                     id="table2"
+                     id="office_select_table"
                      @row-clicked="rowClicked">
               <template slot="office_name" slot-scope="data">
                 <div>
@@ -288,6 +286,8 @@ export const TimeQuestion = Vue.component('date-question', {
         enableTime: true,
         noCalendar: true,
         static: true,
+        dateFormat: 'h:i K',
+        time_24hr: false,
         minTime: '8:00',
         maxTime: '17:00',
         minuteIncrement: 15,

--- a/frontend/src/exams/add-exam-form-modal.vue
+++ b/frontend/src/exams/add-exam-form-modal.vue
@@ -94,7 +94,7 @@
                  align-content="center">
             <b-col>
               <p class="message-text">Something Went Wrong</p>
-              <p><b-button>Try Again</b-button></p>
+              <p><b-button @click="()=>{updateCaptureTab({step:4})}">Try Again</b-button></p>
             </b-col>
           </b-row>
         </b-container>
@@ -241,9 +241,10 @@
       submit() {
         this.unSubmitted = false
         this.submitMsg = ''
-        if (this.user.role.role_code === 'LIAISON') {
+        if (this.addITAExamModal.setup === 'group') {
           this.clickAddExamSubmit('group_ita')
-        } else {
+        }
+        if (this.addITAExamModal.setup === 'individual') {
           this.clickAddExamSubmit('ind_ita')
         }
       },

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -1,8 +1,8 @@
 <template v-if="showExams">
   <div>
     <b-form inline>
-      <b-button class="mr-1" @click="clickAddIndividual">Add Individual Exam</b-button>
-      <b-button class="mx-2" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
+      <b-button class="mr-1 btn-primary" @click="clickAddIndividual">Add Individual Exam</b-button>
+      <b-button class="mx-2 btn-primary" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
     </b-form>
     <AddExamFormModal />
   </div>

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -1,46 +1,128 @@
 <template>
-  <div class="px-3">
-    <b-col md="6" class="my-1">
-      <b-form-group horizontal label="Filter" class="mb-0">
-        <b-input-group>
-          <b-form-input v-model="filter" placeholder="Type to Search" />
-          <b-input-group-append>
-            <b-btn :disabled="!filter" @click="filter = ''">Clear</b-btn>
-          </b-input-group-append>
-        </b-input-group>
-      </b-form-group>
-    </b-col>
-    <b-table :items="selectedExams"
-             :fields=getFields
-             class="m-0 p-0"
-             head-variant="light"
-             empty-text="There are no exams that match this filter criteria"
-             small
-             outlined
-             @row-clicked="clickRow"
-             hover
-             show-empty
-             :filter="filter">
+  <div>
+    <b-form inline class="ml-3">
+      <b-input-group>
+        <b-input-group-prepend><label class="mx-1 pt-1 my-auto label-text">Search</label></b-input-group-prepend>
+        <b-input size="sm" class="mb-1 mt-3" v-model="filter"></b-input>
+      </b-input-group>
+      <b-input-group class="ml-3">
+        <b-input-group-prepend>
+          <label class="mx-1 pt-1 my-auto label-text">Filters</label>
+        </b-input-group-prepend>
+        <b-btn-group horizontal class="pt-2">
+          <b-btn value="all"
+                 size="sm"
+                 :pressed="expiryFilter==='all'"
+                 @mousedown="storeLocally"
+                 @click="expiryFilter='all'"><span class="mx-2">All</span></b-btn>
+          <b-btn value="expired"
+                 size="sm"
+                 :pressed="expiryFilter==='expired'"
+                 @mousedown="storeLocally"
+                 @click="expiryFilter='expired'">Expired</b-btn>
+          <b-btn value="current"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="expiryFilter==='current'"
+                 @click="expiryFilter='current'">Current</b-btn>
+        </b-btn-group>
+        <b-btn-group horizontal class="ml-2 pt-2">
+          <b-btn value="both"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="bookedFilter==='both'"
+                 @click="bookedFilter='both'"><span class="mx-2">Both</span></b-btn>
+          <b-btn value="unbooked"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="bookedFilter==='unbooked'"
+                 @click="bookedFilter='unbooked'">Un-Booked</b-btn>
+          <b-btn value="booked"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="bookedFilter==='booked'"
+                 @click="bookedFilter='booked'">Booked</b-btn>
+        </b-btn-group>
+        <b-btn-group horizontal class="ml-2 pt-2">
+          <b-btn value="both"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="groupFilter==='both'"
+                 @click="groupFilter='both'"><span class="mx-2">Both</span></b-btn>
+          <b-btn value="unbooked"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="groupFilter==='individual'"
+                 @click="groupFilter='individual'">Individual</b-btn>
+          <b-btn value="booked"
+                 size="sm"
+                 @mousedown="storeLocally"
+                 :pressed="groupFilter==='group'"
+                 @click="groupFilter='group'">Group</b-btn>
+        </b-btn-group>
+      </b-input-group>
+    </b-form>
+    <div :style="tableStyle" class="exam-table-holder my-0 mx-3">
+      <b-table :items="filteredExams"
+               :fields=getFields
+               head-variant="light"
+               style="border: 1px solid dimgrey"
+               empty-text="There are no exams that match this filter criteria"
+               small
+               outlined
+               @row-clicked="clickRow"
+               hover
+               show-empty
+               :filter="filter">
+        <template slot="student_name" slot-scope="row">
+          {{ row.item === 'group' ? 'Group Exam' : row.item }}
+        </template>
       <template slot="exam_received" slot-scope="row">
         {{ row.item.exam_received === 0 ? 'No' : 'Yes' }}
       </template>
+        <template slot="booking_"
       <template slot="invigilator" slot-scope="row">
         {{ getInvigilator(row) }}
       </template>
       <template slot="expiry_date" slot-scope="row">
         {{ row.item.expiry_date.split('T')[0] }}
       </template>
+      <template slot="location" slot-scope="row">
+        <template v-if="!row.item.offsite_location">
+          <span v-if="row.item.booking">
+            <b-btn variant="link" class="open-cal-link" @click="openEditBooking">
+                {{ row.item.booking.room.room_name }}
+            </b-btn>
+          </span>
+          <span v-else><b-btn variant="link" class="schedule-link" to="/booking">Schedule</b-btn></span>
+        </template>
+        <span v-if="row.item.offsite_location">
+          <b-btn variant="link" class="view-details-link" @click.stop="row.toggleDetails">
+            {{ row.detailsShowing ? 'Hide' : 'Show'}} Details
+          </b-btn>
+        </span>
+      </template>
+        <template slot="row-details" slot-scope="row">
+          <span class="mb-2 mt-0 ml-3"><b>Location: </b>{{ row.item.offsite_location }}</span>
+        </template>
       <template slot="actions" slot-scope="row">
-        <b-dropdown variant="outline-primary"
+        <b-dropdown variant="link"
+                    no-caret
+                    size="sm"
                     class="pl-0 ml-0 mr-3"
                     id="nav-dropdown"
-                    right text="">
+                    right>
+          <template slot="button-content">
+            <font-awesome-icon icon="caret-down"
+                               style="padding: -2px; margin: -2px; font-size: 1rem; color: dimgray"/>
+          </template>
           <b-dropdown-item size="sm" @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
           <b-dropdown-item size="sm" @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
           <b-dropdown-item v-if=row.item.booking size="sm" @click="updateBookingRoute(row.item, row.index)">Update Booking</b-dropdown-item>
         </b-dropdown>
       </template>
     </b-table>
+    </div>
     <EditExamModal v-if="showEditExamModalVisible"></EditExamModal>
     <ReturnExamModal v-if="showReturnExamModalVisible"></ReturnExamModal>
   </div>
@@ -58,25 +140,117 @@
     name: "ExamInventoryTable",
     components: { EditExamModal, ReturnExamModal, SuccessExamAlert, FailureExamAlert },
     props: ['mode'],
+    mounted() {
+      this.getBookings().then(bookings => {
+        this.events = bookings
+      })
+      this.getWidth()
+      this.getExams()
+      this.$nextTick(function() {
+        window.addEventListener('resize', () => { this.getWidth() })
+      })
+    },
     data() {
       return {
+        tableStyle: null,
+        expiryFilter: 'all',
+        bookedFilter: 'both',
+        groupFilter: 'both',
         filter: null,
         events: null,
         fields: [
-          {key: 'office.office_name', label: 'Office', sortable: true},
-          {key: 'event_id', label: 'Event ID', sortable: false },
-          {key: 'exam_name', label: 'Exam Name', sortable: true },
-          {key: 'exam_method', label: 'Method', sortable: false },
-          {key: 'expiry_date', label: 'Expiry Date', sortable: true },
-          {key: 'exam_received', label: 'Received?', sortable: true },
-          {key: 'examinee_name', label: 'Student Name', sortable: true },
-          {key: 'notes', label: 'Notes', sortable: false },
-          {key: 'invigilator', label: 'Invigilator', sortable: true },
-          {key: 'booking.room.room_name', label: 'Location', sortable: true },
-          {key: 'actions', label: 'Actions', sortable: false}
+          {key: 'office.office_name', label: 'Office', sortable: true, thStyle: 'width: 8%'},
+          {key: 'event_id', label: 'Event ID', sortable: true, thStyle: 'width: 6%' },
+          {key: 'exam_name', label: 'Exam Name', sortable: true, thStyle: 'width: 11%' },
+          {key: 'exam_method', label: 'Method', sortable: true, thStyle: 'width: 5%' },
+          {key: 'expiry_date', label: 'Expiry Date', sortable: true, thStyle: 'width: 8%' },
+          {key: 'exam_received', label: 'Received?', sortable: true, thStyle: 'width: 5%' },
+          {key: 'examinee_name', label: 'Student Name', sortable: true, thStyle: 'width: 12%' },
+          {key: 'notes', label: 'Notes', sortable: true, thStyle: 'width: 21%' },
+          {key: 'invigilator', label: 'Invigilator', sortable: true, thStyle: 'width: 10%' },
+          {key: 'location', label: 'Location', sortable: true, thStyle: 'width: 9%' },
+          {key: 'actions', label: 'Actions', sortable: true, thStyle: 'width: 5%' }
         ],
         bookingRouteString: '',
       }
+    },
+    computed: {
+      ...mapGetters(['calendar_events', 'exam_inventory', 'role_code',]),
+      ...mapState([
+        'bookings',
+        'calendarSetup',
+        'exams',
+        'showEditExamModalVisible',
+        'showExamInventoryModal',
+        'showReturnExamModalVisible',
+        'user',
+      ]),
+      filteredExams() {
+        let exams = this.exam_inventory || []
+        let filtered = []
+        switch (this.expiryFilter) {
+          case 'all':
+            filtered = exams
+            break
+          case 'expired':
+            filtered = exams.filter(ex=>moment(ex.expiry_date).isBefore(moment(), 'day'))
+            break
+          case 'current':
+            filtered = exams.filter(ex=>moment(ex.expiry_date).isSameOrAfter(moment(), 'day'))
+            break
+          default:
+            filtered = exams
+            break
+        }
+        let moreFiltered = []
+        switch (this.bookedFilter) {
+          case 'both':
+            moreFiltered = filtered
+            break
+          case 'unbooked':
+            moreFiltered = filtered.filter(ex=>!ex.booking)
+            break
+          case 'booked':
+            moreFiltered = filtered.filter(ex=>ex.booking)
+            break
+          default:
+            moreFiltered = filtered
+            break
+        }
+        let evenMoreFiltered = []
+        switch (this.groupFilter) {
+          case 'both':
+            evenMoreFiltered = moreFiltered
+            break
+          case 'individual':
+            evenMoreFiltered = moreFiltered.filter(ex=>!ex.offsite_location)
+            break
+          case 'group':
+            evenMoreFiltered = moreFiltered.filter(ex=>ex.offsite_location)
+            break
+          default:
+            evenMoreFiltered = moreFiltered
+            break
+        }
+        return evenMoreFiltered
+      },
+      selectedExams() {
+        if (this.showExamInventoryModal) {
+          return this.exam_inventory
+        }
+        return this.exams
+      },
+      getFields() {
+        if (this.role_code === "LIAISON") {
+          return this.fields
+        } else {
+          let returnFields = this.fields
+          let index = this.fields.findIndex(x => x.key === "office.office_name")
+          returnFields.splice(index, 1)
+          return returnFields
+        }
+      }
+
     },
     methods: {
       ...mapActions(['getExams', 'getBookings']),
@@ -92,6 +266,26 @@
         'toggleReturnExamModalVisible',
         'setReturnExamInfo'
       ]),
+      storeLocally(e) {
+        console.log(e)
+      },
+      handleExpiryFilter(e) {
+        this.expiryFilter = e.target.value
+      },
+      openEditBooking() {
+
+      },
+      getWidth() {
+        this.tableStyle = {width: `${window.innerWidth - 40}px`}
+      },
+      handleBookedFilter(e) {
+        this.bookedFilter = e.target.value
+      },
+      resetButtons() {
+        this.buttons.all = 'btn-secondary'
+        this.buttons.current = 'btn-secondary'
+        this.buttons.expired = 'btn-secondary'
+      },
       getInvigilator(row) {
         if (this.events) {
           let bookingObj = this.events.find(event=>event.booking_id==row.item.booking_id)
@@ -128,47 +322,55 @@
         this.$router.push(dateConcat)
       }
     },
-    mounted() {
-      this.getBookings().then(bookings => {
-        this.events = bookings
-      })
-      this.getExams()
-    },
-    computed: {
-      ...mapGetters([ 'role_code',
-                      'exam_inventory',
-                      'calendar_events']),
-      ...mapState([ 'user',
-                    'exams',
-                    'showExamInventoryModal',
-                    'bookings',
-                    'showEditExamModalVisible',
-                    'showReturnExamModalVisible',
-                    'calendarSetup' ]),
-      selectedExams() {
-        if (this.showExamInventoryModal) {
-          return this.exam_inventory
-        }
-        return this.exams
-      },
-      getFields() {
-        if (this.role_code === "LIAISON") {
-          return this.fields
-        } else {
-          let returnFields = this.fields
-          let index = this.fields.findIndex(x => x.key === "office.office_name")
-          returnFields.splice(index, 1)
-          return returnFields
-        }
-      }
-
-    }
   }
 </script>
 
-invigilatorNull() {
-  if (fields.booking.invigilator.invigilator_name) {
-    return fields.booking.invigilator.invigilator_name
+<style scoped>
+  .open-cal-link {
+    text-decoration: #007bff underline !important;
+    text-underline-position: under;
+    font-size: .85rem;
+    color: #007bff !important;
+    font-weight: 300;
   }
-  return null
-}
+  .view-details-link {
+    text-decoration: #007bff underline !important;
+    text-underline-position: under;
+    font-size: .85rem;
+    color: #007bff !important;
+    font-weight: 300;
+  }
+  .view-details-link:hover {
+    font-weight: 600;
+  }
+  .open-cal-link:hover {
+    font-weight: 600;
+  }
+  .schedule-link {
+    text-decoration: #28a745 underline !important;
+    text-underline-position: under;
+    font-size: .85rem;
+    color: #28a745 !important;
+    font-weight: 300;
+  }
+  .schedule-link:hover {
+    font-weight: 600;
+  }
+  .btn {
+    border: none !important;
+  }
+  .label-text {
+    font-size: .9rem;
+  }
+  .btn {
+    border: none !important;
+    box-shadow: none !important;
+    transition: none !important;
+  }
+  .btn:active, .btn.active {
+    background-color: darkgrey !important;
+  } color: blue !important;
+  .exam-table-holder {
+    border: 1px solid dimgrey;
+  }
+</style>

--- a/frontend/src/exams/inventory-filters.vue
+++ b/frontend/src/exams/inventory-filters.vue
@@ -1,29 +1,11 @@
 <template>
-  <div class="inv-filters-container">
-    <b-form>
-      <b-form-row>
-        <b-col cols="6>
-          <b-btn variant="outline-primary" :pressed="expired">Expired</b-btn>
-        </b-col>
-        <b-col cols="6">
-          <b-btn variant="outline-primary" :pressed="written">Written</b-btn>
-        </b-col>
-      </b-form-row>
-      <b-form-row>
-        <b-col cols="6>
-          <b-btn variant="outline-primary" :pressed="unreturn">Expired</b-btn>
-        </b-col>
-        <b-col cols="6">
-          <b-btn variant="outline-primary" :pressed="expired">Written</b-btn>
-        </b-col>
-      </b-form-row>
-    </b-form>
-  </div>
+
 </template>
 
 <script>
   export default {
     name: "InventoryFilters",
+    props: ['']
     data() {
       return {
         expired: false,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -26,18 +26,19 @@ import './assets/css/bc-gov-style.css'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { InputNumber } from 'element-ui'
 import {
-  faPlus,
-  faMinus,
   faAngleLeft,
   faAngleRight,
   faBars,
   faBinoculars,
   faCalendar,
+  faCaretDown,
   faCaretLeft,
   faCaretRight,
   faCheck,
   faExclamation,
   faFilter,
+  faMinus,
+  faPlus,
   faSort,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
@@ -45,8 +46,6 @@ import VDragged from 'v-dragged'
 
 Vue.use(VDragged)
 library.add(
-  faPlus,
-  faMinus,
   faAngleLeft,
   faAngleRight,
   faBars,
@@ -54,9 +53,12 @@ library.add(
   faCalendar,
   faCaretLeft,
   faCaretRight,
+  faCaretDown,
   faCheck,
   faExclamation,
   faFilter,
+  faMinus,
+  faPlus,
   faSort,
 )
 Vue.component('font-awesome-icon', FontAwesomeIcon)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1601,6 +1601,7 @@ export const store = new Vuex.Store({
           additionalKeys = {
             exam_received: 1,
             exam_returned_ind: 0,
+            number_of_students: 1,
             office_id: context.state.user.office_id
           }
           break
@@ -1609,7 +1610,7 @@ export const store = new Vuex.Store({
           additionalKeys = {
             exam_received: 0,
             exam_returned_ind: 0,
-            exam_name: 'group exam'
+            examimee_name: 'group exam'
           }
           break
         default:
@@ -1620,6 +1621,9 @@ export const store = new Vuex.Store({
       keys.forEach(key => {
         examObj[key] = capturedExam[key]
       })
+      if (!keys.includes('notes')) {
+        examObj['notes'] = ' '
+      }
       if (payload === 'group_ita') {
         let datestring = examObj.expiry_date + ' ' + examObj.exam_time
         examObj.expiry_date = new moment(datestring).local().utc().format('YYYY-MM-DD[T]HH:mm:ssZ')


### PR DESCRIPTION
Improved the add exam workflow including addition of flatpickr.js for time selection, an 'add another exam' button at the end, and sepperated the access to the form to another button visible only to the LIAISON role.  Added filters to the exam inventory table for Group vs. Individual, Expired vs Current, and Booked vs Unbooked, as well as modified the location column to handle the longer location data associated with group exam bookings.  also fixed an issue causing the agenda and bookings views to render incorrectly when there are no bookings to display