### PR TITLE
Monthly Financial Reporting - Office/Exam Group Filtering

### DIFF
--- a/api/app/resources/bookings/booking/booking_post.py
+++ b/api/app/resources/bookings/booking/booking_post.py
@@ -43,6 +43,9 @@ class BookingPost(Resource):
             logging.warning("WARNING: %s", warning)
             return {"message": warning}, 422
 
+        if booking.office_id is None:
+            booking.office_id = csr.office_id
+
         if booking.office_id == csr.office_id or csr.role_code == "LIAISON":
             db.session.add(booking)
             db.session.commit()

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -140,6 +140,7 @@ import app.resources.bookings.exam.exam_detail
 import app.resources.bookings.exam.exam_list
 import app.resources.bookings.exam.exam_post
 import app.resources.bookings.exam.exam_put
+import app.resources.bookings.exam.exam_export_list
 import app.resources.bookings.invigilator.invigilator_list
 import app.resources.bookings.room.room_list
 import app.resources.bookings.exam_type.exam_type_list

--- a/frontend/src/exams/generate-financial-report-modal.vue
+++ b/frontend/src/exams/generate-financial-report-modal.vue
@@ -16,11 +16,34 @@
       </b-row>
       <b-row class="my-1">
         <b-col sm="4"><label>Start Date:</label></b-col>
-        <b-col sm="6"><b-form-input id="startDate" type="date" v-model=startDate></b-form-input></b-col>
+        <b-col sm="6">
+          <b-form-input id="startDate"
+                        type="date"
+                        v-model=startDate />
+        </b-col>
       </b-row>
       <b-row class="my-1">
         <b-col sm="4"><label>End Date:</label></b-col>
-        <b-col sm="6"><b-form-input id="endDate" type="date" v-model=endDate></b-form-input></b-col>
+        <b-col sm="6"><b-form-input id="endDate"
+                                    type="date"
+                                    v-model=endDate />
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col sm="4"><label>Exam Types:</label></b-col>
+        <b-col sm="6>">
+          <b-form-group>
+            <b-form-radio-group :options="options"
+                                stacked
+                                v-model="selectedExamType" />
+          </b-form-group>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col sm="4"><label>Office:</label></b-col>
+        <b-col sm="6">
+          <OfficeDropDownFilter />
+        </b-col>
       </b-row>
     </b-container>
   </b-modal>
@@ -28,35 +51,64 @@
 
 <script>
     import { mapState, mapMutations, mapActions } from 'vuex'
+    import OfficeDropDownFilter from './office-dropdown-filter'
+    import moment from 'moment'
+    const FileDownload = require('js-file-download')
     export default {
         name: "FinancialReportModal",
+        components: {
+          OfficeDropDownFilter,
+        },
+        mounted() {
+          this.getOffices()
+        },
         data() {
           return {
             startDate: '',
             endDate: '',
+            options: [
+              {text: 'ITA - Individual', value: 'ita_individual'},
+              {text: 'ITA - Group', value: 'ita_group'},
+              {text: 'Pesticide', value: 'pesticide'},
+              {text: 'Bulk Milk Tank Grader', value: 'milk_tank'}
+            ],
+            selectedExamType: '',
           }
         },
         methods: {
           ...mapActions([
-            'getExamsExport'
+            'getExamsExport',
+            'getExamTypes',
+            'getOffices'
           ]),
           ...mapMutations([
-            'toggleGenFinReport'
+            'toggleGenFinReport',
+            'setSelectedOffice'
           ]),
           submit() {
-
-            console.log("Pressed Submit")
             let form_start_date = this.startDate
             let form_end_date = this.endDate
-            let url= '/exams/export/?start_date=' + form_start_date + '&end_date=' + form_end_date
+            let exam_type = this.selectedExamType
+            let office_name = this.selectedOffice
+            let url = '/exams/export/?start_date=' + form_start_date + '&end_date=' + form_end_date + '&exam_type='
+                      + exam_type + '&office_name=' + office_name
+            let today = moment().format('YYYY-MM-DD_HHMMSS')
+            let filename = 'export-csv-' + today + '.csv'
             this.getExamsExport(url)
-                .then(resp => { const FileDownload = require('js-file-download')
-                                                    FileDownload(resp.data, 'export.csv')})
+              .then(resp => {
+                FileDownload(resp.data, filename)
+              })
+            this.startDate = ''
+            this.endDate = ''
+            this.selectedExamType = ''
+            this.setSelectedOffice('')
           },
         },
         computed: {
           ...mapState({
             showGenFinReportModal: state => state.showGenFinReportModal,
+            offices: state => state.offices,
+            selectedOffice: state => state.selectedOffice,
           }),
           modal: {
             get() {
@@ -66,10 +118,9 @@
               this.toggleGenFinReport(e)
             }
           },
-        },
+        }
     }
 </script>
 
 <style scoped>
-
 </style>

--- a/frontend/src/exams/office-dropdown-filter.vue
+++ b/frontend/src/exams/office-dropdown-filter.vue
@@ -10,7 +10,7 @@
                 <b-dd-item @click="handleClick"
                            v-if="officeList.length > 0"
                            :name="office.office_name"
-                           :id="office.office_id">{{ office.office_name + ', #' + office.office_id }}</b-dd-item>
+                           :id="office.office_id">{{ office.office_name }}</b-dd-item>
                 <b-dd-item v-if="officeList.length === 0">No matching offices</b-dd-item>
 
               </template>
@@ -22,7 +22,7 @@
 </template>
 
 <script>
-  import { mapActions, mapState } from 'vuex'
+  import { mapActions, mapState, mapMutations } from 'vuex'
 
   export default {
     name: "OfficeDropDownFilter",
@@ -38,7 +38,7 @@
       }
     },
     computed: {
-      ...mapState([ 'offices' ]),
+      ...mapState([ 'offices', 'selectedOffice' ]),
       officeList() {
         if (this.searching === true) {
           if (this.offices && this.offices.length > 0) {
@@ -60,6 +60,7 @@
         this.search = e
         if (this.search.length > 1 && this.searching === true) {
           this.menuClass = 'dropdown-menu show py-0 my-0 w-100'
+          this.setSelectedOffice(this.search)
         }
         if (this.search.length <= 1) {
           this.searching = false
@@ -71,6 +72,7 @@
         this.searching = false
         this.menuClass = 'dropdown-menu'
       },
+      ...mapMutations(['setSelectedOffice'])
     },
   }
 </script>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -312,6 +312,7 @@ export const store = new Vuex.Store({
     schedulingOther: false,
     selectedBooking: {},
     selectedExam: {},
+    selectedOffice: {},
     selectionIndicator: false,
     serveModalAlert: '',
     serveNowAltAction: false,
@@ -2138,6 +2139,10 @@ export const store = new Vuex.Store({
     setMainAlert(state, payload) {
       state.alertMessage = payload
       state.dismissCount = 5
+    },
+
+    setSelectedOffice(state, payload) {
+      state.selectedOffice = payload
     },
 
     setExamAlert(state, payload) {


### PR DESCRIPTION
A CSR/GA/Liaison will require the ability to generate financial reports based on type of exam as well as for a specific office. This PR contains the added functionality to add an exam_type and office_name url parameter to the url used to export a csv to the clients browser. At this moment in time, both parameters are not required or used when creatiung the CSV, but will be required in future development when generating these csv files.