### PR TITLE
Booking Exam From Exam Admin Inventory Table

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -36,7 +36,7 @@
                      @event-created="selectEvent"
                      @event-render="eventRender"
                      :events="events()"
-                     :config="setup">
+                     :config="config">
       </full-calendar>
     </keep-alive>
     <div class="w-50 mt-2 ml-3 pl-3" style="display: flex; justify-content: space-between;"
@@ -99,6 +99,7 @@
       this.$root.$on('toggleOffsite', (bool) => { this.toggleOffsite(bool) })
       this.$root.$on('unselect', () => { this.unselect() })
       this.$root.$on('updateEvent', (event, params) => { this.updateEvent(event, params) })
+
     },
     data() {
       return {
@@ -177,6 +178,11 @@
         'showExamInventoryModal',
         'showSchedulingIndicator',
       ]),
+      config() {
+        let setup = this.setup
+        setup.selectable = true
+        return setup
+      },
       adjustment() {
         if (this.showSchedulingIndicator) {
           return 240
@@ -479,6 +485,11 @@
           this.$refs.bookingcal.fireMethod('changeView', 'agendaDay')
           this.goToDate(this.$route.params.date)
         }
+        if(this.$route.params.schedule == true) {
+          this.$refs.bookingcal.fireMethod('changeView', 'agendaWeek')
+          this.toggleOffsite(false)
+          this.options({name: 'selectable', value: true})
+      }
       },
     }
   }

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -107,9 +107,16 @@
             <font-awesome-icon icon="caret-down"
                                style="padding: -2px; margin: -2px; font-size: 1rem; color: dimgray"/>
           </template>
-          <b-dropdown-item size="sm" @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
-          <b-dropdown-item size="sm" @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
-          <b-dropdown-item v-if=row.item.booking size="sm" @click="updateBookingRoute(row.item, row.index)">Update Booking</b-dropdown-item>
+          <b-dropdown-item size="sm"
+                           @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
+          <b-dropdown-item size="sm"
+                           @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
+          <b-dropdown-item v-if=row.item.booking
+                           size="sm"
+                           @click="updateBookingRoute(row.item, row.index)">Edit Booking</b-dropdown-item>
+          <b-dropdown-item v-else-if=!row.item.booking
+                           size="sm"
+                           @click="addBookingRoute(row.item, row.index)">Add Booking</b-dropdown-item>
         </b-dropdown>
       </template>
     </b-table>
@@ -270,7 +277,7 @@
         'toggleEditExamModalVisible',
         'setEditExamInfo',
         'toggleReturnExamModalVisible',
-        'setReturnExamInfo'
+        'setReturnExamInfo',
       ]),
       handleExpiryFilter(e) {
         this.expiryFilter = e.target.value
@@ -326,6 +333,16 @@
         let rowDate = moment(item.booking.start_time).format('YYYY-MM-DD')
         let dateConcat = bookingRoute.concat(rowDate)
         this.$router.push(dateConcat)
+      },
+      addBookingRoute(item) {
+        let bookingRoute = '/booking/?schedule=true'
+        this.$router.push(bookingRoute)
+        this.navigationVisible(false)
+        this.setSelectedExam(item)
+        this.toggleCalendarControls(false)
+        this.toggleExamInventoryModal(false)
+        this.toggleScheduling(true)
+        this.toggleSchedulingIndicator(true)
       }
     },
   }


### PR DESCRIPTION
After client testing, it was determined that the exam inventory table on the exam admin feature required the ability for exams that were not already booked, to be booked. Logic in the PR looks at an exam, and if it has not been booked, a dropdown item in the actions field will appear to Book this exam. Once clicked, the user is taken to the booking calendar feature (week view) and placed into scheduling mode with the exam that was clicked to be added. There the user can click on the calendar to place the exam into whatever time slot, in whatever room they want.