### PR TITLE
Capture Non ITA Exams

### DIFF
--- a/api/migrations/sql_scripts/exam_types.sql
+++ b/api/migrations/sql_scripts/exam_types.sql
@@ -1,0 +1,34 @@
+user qsystem;
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('COFQ - 3HR Group Exam', '#FF69B4', 3, 'Written', 1 , 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('COFQ - 3HR Single Exam', '#FF69B4', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('COFQ - 3HR Single Exam - Own Reader', '#FF69B4', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('COFQ - 3HR Single Exam - SBC Reader', '#FF69B4', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('COFQ - 3HR Single Exam - Time Extension', '#FF69B4', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('IPSE - 4HR Group Exam', '#FFD701', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('IPSE - 4HR Single Exam', '#FFD701', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('IPSE - 4HR Single Exam - Own Reader', '#FFD701', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('IPSE - 4HR Single Exam - SBC Reader', '#FFD701', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('IPSE - 4HR Single Exam - Time Extension', '#FFD701', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('SLE - 3HR Group Exam', '#8FBC8F', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('SLE - 3HR Single Exam', '#8FBC8F', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('SLE - 3HR Single Exam - Own Reader', '#8FBC8F', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('SLE - 3HR Single Exam - SBC Reader', '#8FBC8F', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('SLE - 3HR Single Exam - Time Extension', '#8FBC8F', 3, 'Written', 1, 0)
+
+insert examtypes (exam_type_name, exam_color, number_of_hours, method_type, ita_ind, group_exam_ind) values ('Challenger Exam Session', '#FFFFFF', 3, 'Written', 1, 0)
+

--- a/api/migrations/sql_scripts/offices.sql
+++ b/api/migrations/sql_scripts/offices.sql
@@ -1,0 +1,85 @@
+use qsystem;
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (4, 'Smithers', 2, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (5, 'Nelson', 3, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (6, 'Castlegar', 4, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (7, 'Merrit', 5, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (8, 'Kamloops', 6, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (9, 'Keremeos', 7, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (10, 'Cranbrook', 8, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (11, 'Dees Lake', 9, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (12, 'Mission', 10, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (14, 'Prince George', 14, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (15, 'Nakusp', 15, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (16, 'Langley', 16, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (17, 'Revelstoke', 17, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (18, 'Vernon', 18, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (19, 'Golden', 19, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (20, 'Lilooet', 19, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (21, 'Prince Rupert', 21, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (22, 'Nanaimo', 22, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (23, 'Ladysmith', 23, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (24, 'Courtney', 24, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (25, 'Hope', 25, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (26, 'Abbottsford', 26, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (27, 'Chilliwack', 27, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (28, 'Osoyoos', 28, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (29, 'Coquitlam', 29, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (30, 'Salmon Arm', 30, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (31, 'Creston', 31, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (32, 'Salmo', 32, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (33, 'Kitimat', 33, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (34, 'Port Hardy', 34, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (35, 'Dawson Creek', 35, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (36, 'Kelowna', 36, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (37, 'Surrey', 37, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (38, 'Terrace', 38, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (39, 'Penticton', 39, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (40, 'Powell River', 40, 2, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (41, 'Squamish', 41, 3, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (43, 'Trail', 43, 1, null, 0);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (44, 'Lumby', 44, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (45, 'Williams Lake', 45, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (46, 'Princeton', 46, 1, null, 1);
+
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (47, 'Shuswap Lake', 47, 2, null, 1);

--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -343,13 +343,19 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
     }
   },
   computed: {
-    ...mapState(['addITAExamModal', 'capturedExam']),
+    ...mapState(['addITAExamModal', 'capturedExam', 'nonITAExam' ]),
     dropItems() {
+      if (this.addITAExamModal.setup === 'individual' && !this.nonITAExam) {
+        return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
+      }
+      if(this.addITAExamModal.setup === 'individual' && this.nonITAExam) {
+        //this.examTypes.forEach(type => {
+          //console.log(type)
+        //})
+        return this.examTypes.filter(type  => type.ita_ind === 0)
+      }
       if (this.addITAExamModal.setup === 'group') {
         return this.examTypes.filter(type => type.exam_type_name.includes('Group'))
-      }
-      if (this.addITAExamModal.setup === 'individual') {
-        return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
       }
     },
     inputText() {
@@ -374,7 +380,7 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
     }
   },
   methods: {
-    ...mapMutations(['toggleAddITAExamModal']),
+    ...mapMutations(['toggleAddITAExamModal', 'toggleNonITAExamModal']),
     clickInput() {
       if (!this.addITAExamModal.step1MenuOpen) {
         this.toggleAddITAExamModal({step1MenuOpen: true})
@@ -386,7 +392,9 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
   template: `
     <b-row no-gutters>
       <b-col class="dropdown">
-      <h5>{{ addITAExamModal.setup === 'group' ? 'Add a Group Exam' : 'Add an Individual Exam' }}</h5>
+      <h5 v-if="addITAExamModal.setup === 'group' ">Add Group Exam</h5>
+      <h5 v-else-if="addITAExamModal.setup === 'individual' && !this.nonITAExam ">Add Individual ITA Exam</h5>
+      <h5 v-else-if="addITAExamModal.setup === 'individual' && this.nonITAExam ">Add Non-ITA Exam</h5>
       <label>Exam Type</label><br>
         <div @click="clickInput">
           <b-input read-only

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -1,9 +1,10 @@
 <template v-if="showExams">
   <div>
     <b-form inline>
-      <b-button class="mr-1" @click="clickAddIndividual">Add Individual Exam</b-button>
-      <b-button class="mx-2" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
-      <b-button class="mr-1" @click="clickGenFinReport">Generate Financial Report</b-button>
+      <b-button variant="primary" class="mr-1" @click="clickAddIndividual">Add Individual Exam</b-button>
+      <b-button variant="primary" class="mr-1" @click="clickAddNonITA">Add Non-ITA Exam</b-button>
+      <b-button variant="primary" class="mx-2" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
+      <b-button variant="primary" class="mr-1" @click="clickGenFinReport">Generate Financial Report</b-button>
     </b-form>
     <AddExamFormModal />
     <FinancialReportModal />
@@ -19,8 +20,10 @@
     name: "ButtonsExams",
     components: {AddExamFormModal, FinancialReportModal },
     computed: {
-      ...mapState(['user', 'showGenFinReportModal' ]),
-      ...mapGetters(['showExams',]),
+      ...mapState([ 'user',
+                    'showGenFinReportModal',
+                    'addNonITA' ]),
+      ...mapGetters([ 'showExams', ]),
       liaison() {
         if (this.user && this.user.role) {
           return (this.user.role.role_code === 'LIAISON')
@@ -28,15 +31,21 @@
       }
     },
     methods: {
-      ...mapMutations(['toggleAddITAExamModal', 'toggleGenFinReport']),
+      ...mapMutations(['toggleAddITAExamModal', 'toggleGenFinReport', 'toggleNonITAExamModal']),
       clickAddIndividual() {
+        this.toggleNonITAExamModal(false)
         this.toggleAddITAExamModal({visible: true, setup: 'individual'})
       },
       clickAddGroup() {
+        this.toggleNonITAExamModal(false)
         this.toggleAddITAExamModal({visible: true, setup: 'group'})
       },
       clickGenFinReport() {
         this.toggleGenFinReport(true)
+      },
+      clickAddNonITA() {
+        this.toggleNonITAExamModal(true)
+        this.toggleAddITAExamModal({visible: true, setup: 'individual'})
       }
     }
   }

--- a/frontend/src/exams/generate-financial-report-modal.vue
+++ b/frontend/src/exams/generate-financial-report-modal.vue
@@ -2,13 +2,13 @@
   <b-modal v-model="modal"
            :no-close-on-backdrop="true"
            ok-title="Submit"
-           ok-variant="warning"
+           ok-variant="primary"
            hide-ok
            @ok="submit"
            hide-header
            hide-cancel
            size="md">
-    <b-container style="font-size:1.1rem; border:1px solid lightgrey; border-radius: 10px" class="mb-2 pb-3" fluid>
+    <b-container style="font-size:1.1rem; border-radius: 10px" class="mb-2 pb-3" fluid>
       <b-row>
         <b-col>
           <h3>Generate Exam Report</h3>
@@ -39,12 +39,6 @@
           </b-form-group>
         </b-col>
       </b-row>
-      <b-row>
-        <b-col sm="4"><label>Office:</label></b-col>
-        <b-col sm="6">
-          <OfficeDropDownFilter />
-        </b-col>
-      </b-row>
     </b-container>
   </b-modal>
 </template>
@@ -56,19 +50,12 @@
     const FileDownload = require('js-file-download')
     export default {
         name: "FinancialReportModal",
-        components: {
-          OfficeDropDownFilter,
-        },
-        mounted() {
-          this.getOffices()
-        },
         data() {
           return {
             startDate: '',
             endDate: '',
             options: [
-              {text: 'ITA - Individual', value: 'ita_individual'},
-              {text: 'ITA - Group', value: 'ita_group'},
+              {text: 'ITA - Individual and Group ', value: 'ita'},
               {text: 'Pesticide', value: 'pesticide'},
               {text: 'Bulk Milk Tank Grader', value: 'milk_tank'}
             ],
@@ -79,19 +66,16 @@
           ...mapActions([
             'getExamsExport',
             'getExamTypes',
-            'getOffices'
           ]),
           ...mapMutations([
             'toggleGenFinReport',
-            'setSelectedOffice'
           ]),
           submit() {
             let form_start_date = this.startDate
             let form_end_date = this.endDate
             let exam_type = this.selectedExamType
-            let office_name = this.selectedOffice
             let url = '/exams/export/?start_date=' + form_start_date + '&end_date=' + form_end_date + '&exam_type='
-                      + exam_type + '&office_name=' + office_name
+                      + exam_type
             let today = moment().format('YYYY-MM-DD_HHMMSS')
             let filename = 'export-csv-' + today + '.csv'
             this.getExamsExport(url)
@@ -101,14 +85,11 @@
             this.startDate = ''
             this.endDate = ''
             this.selectedExamType = ''
-            this.setSelectedOffice('')
           },
         },
         computed: {
           ...mapState({
             showGenFinReportModal: state => state.showGenFinReportModal,
-            offices: state => state.offices,
-            selectedOffice: state => state.selectedOffice,
           }),
           modal: {
             get() {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -250,6 +250,7 @@ export const store = new Vuex.Store({
       priority: 2
     },
     addModalSetup: null,
+    nonITAExam: false,
     addNextService: false,
     adminNavigation: 'csr',
     alertMessage: '',
@@ -2357,6 +2358,8 @@ export const store = new Vuex.Store({
     setClickedDate: (state, payload) => state.clickedDate = payload,
     
     toggleExamInventoryModal: (state, payload) => state.showExamInventoryModal = payload,
+
+    toggleNonITAExamModal: (state, payload) => state.nonITAExam = payload,
 
     toggleEditExamModalVisible: (state, payload) => state.showEditExamModalVisible = payload,
 


### PR DESCRIPTION
Non-ITA Exam Admins require a way to track vetrinary/milk tank grader exams. In order to do this, modular buttons/modal components were re-used from the add individual ITA exam modal process. The only major difference between Add individual ITA and Add Non-ITA Exam processes is that the exam type drop down shows exam types that do not have their exam type ita_ind field set to 1.