### PR TITLE
Fixed issue with add exam form confirmation

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -279,7 +279,7 @@ export const DateQuestion = Vue.component('date-question', {
     <b-row no-gutters>
       <b-col cols="11">
         <b-form-group>
-          <label>
+          <label class="mr-3">
             {{ addITAExamModal.setup == 'group' ? 'Exam Date' : 'Expiry Date' }}
             <span v-if="error" style="color: red">{{ validationObj[q.key].message }}</span>
           </label>
@@ -316,7 +316,7 @@ export const TimeQuestion = Vue.component('time-question', {
     <b-row no-gutters>
       <b-col cols="11">
         <b-form-group>
-          <label>
+          <label class="mr-3">
             Exam Time
             <span v-if="error" style="color: red">{{ validationObj[q.key].message }}</span>
           </label>

--- a/frontend/src/exams/add-exam-form-confirm.vue
+++ b/frontend/src/exams/add-exam-form-confirm.vue
@@ -16,9 +16,18 @@
         <span class="confirm-header">Exam Type</span>
       </b-col>
       <b-col>
-        <span :style="{color: examObject.exam_type_colour}">
-          {{ examObject.exam_type_name }}
+        <span :style="{color: exam_object.exam_color}">
+          {{ exam_object.exam_type_name }}
         </span>
+      </b-col>
+    </b-row>
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group'">
+      <b-col cols="1" />
+      <b-col cols="3">
+        <span class="confirm-header">Office</span>
+      </b-col>
+      <b-col align-self="end">
+        <span class="confirm-item">{{ officeName }}</span>
       </b-col>
     </b-row>
     <b-row no-gutters align-h="start" align-v="end">
@@ -39,7 +48,7 @@
         <span class="confirm-item">{{ exam.exam_name }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="!user.role.role_code == 'LIAISON'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual'">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Writer's Name</span>
@@ -48,7 +57,7 @@
         <span class="confirm-item">{{ exam.examinee_name }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-else>
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group'">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Students</span>
@@ -57,7 +66,7 @@
         <span class="confirm-item">{{ exam.number_of_students }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="!user.role.role_code == 'LIAISON'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual'">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Received Date</span>
@@ -69,14 +78,13 @@
     <b-row no-gutters align-h="between" align-v="end">
       <b-col cols="1" />
       <b-col cols="3">
-        <span class="confirm-header">{{ user.role.role_code == 'LIAISON' ? 'Exam Date' : 'Expiry Date' }}
-        </span>
+        <span class="confirm-header">{{ setup === 'group' ? 'Exam Date' : 'Expiry Date' }}</span>
       </b-col>
       <b-col align-self="end">
-        <span class="confirm-item">{{ exam.expiry_date }}</span>
+        <span class="confirm-item">{{ formatDate(exam.expiry_date) }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="user.role.role_code == 'LIAISON'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group' ">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Exam Time
@@ -86,7 +94,7 @@
         <span class="confirm-item">{{ displayTime }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="user.role.role_code == 'LIAISON'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group' ">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Location
@@ -96,11 +104,20 @@
         <span class="confirm-item">{{ exam.offsite_location }}</span>
       </b-col>
     </b-row>
+    <b-row no-gutters align-h="between" align-v="end">
+      <b-col cols="1" />
+      <b-col cols="3">
+        <span class="confirm-header">Method</span>
+      </b-col>
+      <b-col align-self="end">
+        <span class="confirm-item">{{ exam.exam_method }}</span>
+      </b-col>
+    </b-row>
   </b-form>
 </template>
 
 <script>
-  import { mapState } from 'vuex'
+  import { mapState, mapGetters } from 'vuex'
   import moment from 'moment'
 
   export default {
@@ -112,7 +129,25 @@
         examTypes: state => state.examTypes,
         tab: state => state.captureITAExamTabSetup,
         user: state => state.user,
+        addITAExamModal: state => state.addITAExamModal,
+        offices: state => state.offices,
       }),
+      ...mapGetters(['exam_object']),
+      officeName() {
+        if (this.addITAExamModal.setup === 'group' && this.exam.office_id) {
+          let office = this.offices.find(o => o.office_id == this.exam.office_id)
+          return `#${office.office_id} - ${office.office_name}`
+        }
+        return ''
+      },
+      setup() {
+        if (this.addITAExamModal.setup === 'individual') {
+          return 'individual'
+        }
+        if (this.addITAExamModal.setup === 'group') {
+          return 'group'
+        }
+      },
       errors() {
         if (this.tab.errors) {
           return this.tab.errors
@@ -127,10 +162,10 @@
         }
         return ''
       },
-      examObject() {
-        if (this.exam && this.exam.exam_type_id) {
-          return this.examTypes.find(type=>type.exam_type_id == this.exam.exam_type_id)
-        }
+    },
+    methods: {
+      formatDate(d) {
+        return new moment(d).format('MMM D, YYYY')
       }
     }
   }

--- a/frontend/src/exams/add-exam-form-controller.vue
+++ b/frontend/src/exams/add-exam-form-controller.vue
@@ -86,11 +86,6 @@
     mounted() {
       this.getExamTypes()
       this.getOffices()
-    //assigning an empty value to notes so it gets picked up by submitter function later if not filled in by user
-      this.captureExamDetail({key:'notes', value: ''})
-      let d = new Date()
-      let today = moment(d).format('YYYY-MM-DD')
-      this.captureExamDetail({key:'exam_received_date', value: today})
     },
     data() {
       return {

--- a/frontend/src/exams/add-exam-form-modal.vue
+++ b/frontend/src/exams/add-exam-form-modal.vue
@@ -108,6 +108,7 @@
   import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
   import AddExamFormController from './add-exam-form-controller'
   import AddExamFormConfirm from './add-exam-form-confirm'
+  import moment from 'moment'
 
   export default {
     name: 'AddExamFormModal',
@@ -183,6 +184,7 @@
     methods: {
       ...mapActions(['clickAddExamSubmit', 'getExams']),
       ...mapMutations([
+        'captureExamDetail',
         'resetCaptureForm',
         'resetCaptureTab',
         'toggleAddITAExamModal',
@@ -197,7 +199,6 @@
               if (this.steps.some(step=>step.step==error)) {
                 list.push(this.steps.find(step=>step.step==error)).questions
               }
-
             })
           if (list.includes(i)) {
             return {color: 'red'}
@@ -232,6 +233,10 @@
         this.updateCaptureTab({step: e})
       },
       initialize() {
+        this.captureExamDetail({key:'notes', value: 'hhh'})
+        let d = new Date()
+        let today = moment(d).format('YYYY-MM-DD')
+        this.captureExamDetail({key:'exam_received_date', value: today})
         this.unSubmitted = true
         this.submitMsg = ''
       },


### PR DESCRIPTION
Fixed issue whereby the confirmation page rendered dates inncorectly and was displaying irelevant headers/missing crucial information.  Also fixed a bug where the question "Was the exam received today" would only default to yes the first time the modal was launched without a page refresh.