### PR TITLE
Fixed issue where click 'Edit Row' did nothing

### DIFF
--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -108,7 +108,7 @@
                                style="padding: -2px; margin: -2px; font-size: 1rem; color: dimgray"/>
           </template>
           <b-dropdown-item size="sm"
-                           @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
+                           @click.stop="editInfo(row.item, row.index)">Edit Exam</b-dropdown-item>
           <b-dropdown-item size="sm"
                            @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
           <b-dropdown-item v-if=row.item.booking

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -2348,7 +2348,7 @@ export const store = new Vuex.Store({
 
     toggleNonITAExamModal: (state, payload) => state.nonITAExam = payload,
 
-    toggleEditExamModalVisible: (state, payload) => state.showEditExamModalVisible = payload,
+    toggleEditExamModalVisible: (state, payload) => state.showEditExamModal = payload,
 
     toggleReturnExamModalVisible: (state, payload) => state.showReturnExamModalVisible = payload,
 


### PR DESCRIPTION
Clicking 'Edit Row' from the exam inventory table had no effect due to some property renaiming in the store that wasn't fully reflected throughout the rest of the front end code.  Also renamed 'Edit Row' to 'Edit Exam' for clarity.