### PR TITLE
Fixed 'Edit Booking' functionality in exam inventory table

### DIFF
--- a/frontend/src/assets/css/q.css
+++ b/frontend/src/assets/css/q.css
@@ -39,3 +39,32 @@
 .q-modal-body {
   padding: 0px !important;
 }
+
+.q-info-display-grid-container {
+   border-radius: 7px;
+   border: 1px solid lightgrey;
+   height: 100%;
+   width: 100%;
+   padding: 7px;
+ }
+.q-id-grid-outer {
+  display: grid;
+  grid-template-columns: 2fr 3fr 2fr 3fr;
+}
+.q-id-grid-1st-col {
+  margin-left: auto;
+  margin-right: 20px;
+}
+.q-id-grid-2nd-col {
+  margin-left: auto;
+}
+.q-id-grid-2nd-head {
+  margin-left: 10px;
+}
+.q-id-grid-top-head {
+  grid-column-start: 1;
+  grid-column-end: 5;
+  margin-right: auto;
+  font-weight: 600;
+  padding-bottom: 5px;
+}

--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -23,21 +23,21 @@
         <b-form>
           <b-form-row v-if="examAssociated">
             <b-col class="mb-2">
-              <div class="display-div-box">
-                <div class="outer-grid-q">
-                  <div class="grid-top-head">Exam Details</div>
+              <div class="q-info-display-grid-container">
+                <div class="q-id-grid-outer">
+                  <div class="q-id-grid-top-head">Exam Details</div>
                   <div>Writer:</div>
-                  <div class="grid-1st-col">{{ this.event.exam.examinee_name }}</div>
-                  <div class="grid-2nd-head">Exam:</div>
-                  <div class="grid-2nd-col">{{ this.event.exam.exam_name }}</div>
+                  <div class="q-id-grid-1st-col">{{ this.event.exam.examinee_name }}</div>
+                  <div class="q-id-grid-2nd-head">Exam:</div>
+                  <div class="q-id-grid-2nd-col">{{ this.event.exam.exam_name }}</div>
                   <div>Method:</div>
-                  <div class="grid-1st-col">{{ this.event.exam.exam_method }}</div>
-                  <div class="grid-2nd-head">Event ID:</div>
-                  <div class="grid-2nd-col">{{ this.event.exam.event_id }}</div>
+                  <div class="q-id-grid-1st-col">{{ this.event.exam.exam_method }}</div>
+                  <div class="q-id-grid-2nd-head">Event ID:</div>
+                  <div class="q-id-grid-2nd-col">{{ this.event.exam.event_id }}</div>
                   <div>Duration:</div>
-                  <div class="grid-1st-col">{{ this.event.exam.exam_type.number_of_hours }} hrs</div>
-                  <div class="grid-2nd-head">Expiry:</div>
-                  <div class="grid-2nd-col">{{ expiryDate }}</div>
+                  <div class="q-id-grid-1st-col">{{ this.event.exam.exam_type.number_of_hours }} hrs</div>
+                  <div class="q-id-grid-2nd-head">Expiry:</div>
+                  <div class="q-id-grid-2nd-col">{{ expiryDate }}</div>
                 </div>
               </div>
             </b-col>
@@ -518,34 +518,3 @@
     }
   }
 </script>
-
-<style scoped>
-  .display-div-box {
-    border-radius: 7px;
-    border: 1px solid lightgrey;
-    height: 100%;
-    width: 100%;
-    padding: 7px;
-  }
-  .outer-grid-q {
-    display: grid;
-    grid-template-columns: 2fr 3fr 2fr 3fr;
-  }
-  .grid-1st-col {
-    margin-left: auto;
-    margin-right: 20px;
-  }
-  .grid-2nd-col {
-    margin-left: auto;
-  }
-  .grid-2nd-head {
-    margin-left: 10px;
-  }
-  .grid-top-head {
-    grid-column-start: 1;
-    grid-column-end: 5;
-    margin-right: auto;
-    font-weight: 600;
-    padding-bottom: 5px;
-  }
-</style>

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -1,0 +1,315 @@
+<template>
+  <b-modal v-model="modalVisible"
+           :no-close-on-backdrop="true"
+           hide-header
+           @shown="setValues"
+           hide-footer
+           size="md">
+    <div v-if="showModal">
+      <span style="font-size: 1.5rem; font-weight:600">Edit Group Exam Booking</span>
+      <b-form>
+        <b-form-row>
+          <b-col class="mb-2">
+            <div class="q-info-display-grid-container">
+              <div class="q-id-grid-outer">
+                <div class="id-grid-1st-col w-100 pr-2">
+                </div>
+                <div class="id-grid-1st-col w-100 pr-2">
+                  <div style="display: flex; justify-content: space-between; width: 100%">
+                    <div>Exam:</div>
+                    <div>{{ this.exam.exam_name }}</div>
+                  </div>
+                </div>
+                <div class="pl-2"><b>Event ID:</b></div>
+                <div class="q-id-grid-2nd-col">{{ this.exam.event_id }}</div>
+                <div class="id-grid-1st-col w-100 pr-2">
+                  <div style="display: flex; justify-content: space-between; width: 100%">
+                    <div>Type:</div>
+                    <div>{{ this.exam.exam_type.exam_type_name }}</div>
+                  </div>
+                </div>
+                <div class="pl-2"><b>Writers:</b></div>
+                <div style="margin-left: auto;">{{ this.exam.number_of_students }}</div>
+              </div>
+            </div>
+          </b-col>
+        </b-form-row>
+        <b-form-row v-if="role_code==='LIAISON' || role_code === 'GA'">
+          <b-col cols="6">
+            <b-form-group>
+              <label>Exam Date</label><br>
+              <DatePicker v-model="date"
+                          name="date"
+                          class="w-100"
+                          @input="checkDate"
+                          lang="en"></DatePicker>
+            </b-form-group>
+          </b-col>
+          <b-col cols="6">
+            <b-form-group>
+              <label>Exam Time</label><br>
+              <DatePicker v-model="time"
+                          class="w-100"
+                          :time-picker-options="{ start: '8:00', step: '00:30', end: '17:00' }"
+                          lang="en"
+                          format="h:mm a"
+                          confirm
+                          name="time"
+                          @input="checkTime"
+                          type="time">
+                <template slot="calendar-icon">
+                  <font-awesome-icon icon="clock"
+                                     class="m-0 p-0"
+                                     style="font-size: .9rem;"/>
+                </template>
+              </DatePicker>
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row v-if="role_code==='LIAISON' || role_code === 'GA'">
+          <b-col>
+            <b-form-group>
+              <label>Location</label><br>
+              <b-textarea v-model="offsite_location"
+                          class="mb-0"
+                          :rows="2"
+                          name="offsite_location"
+                          @input.native="checkInput" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row align-content="end" align-h="end">
+          <b-col cols="10" v-if="role_code==='LIAISON' || role_code === 'GA'">
+            <b-form-group>
+              <label>Invigilator</label><br>
+              <b-select v-model="invigilator_id"
+                        name="invigilator_id"
+                        @input.native="checkInput"
+                        :options="invigilatorOptions" />
+            </b-form-group>
+          </b-col>
+          <b-col v-if="role_code!=='LIAISON' && role_code!=='GA'">
+            <b-form-group>
+              <label>Invigilator</label><br>
+              <b-select v-model="invigilator_id"
+                        name="invigilator_id"
+                        @input.native="checkInput"
+                        :options="invigilatorOptions" />
+            </b-form-group>
+          </b-col>
+          <b-col cols="2" align-self="start" v-if="role_code==='LIAISON' || role_code === 'GA'">
+            <label>Clear Form?</label><br>
+            <b-btn class="w-100 btn-warning" @click="setValues">Reset</b-btn>
+          </b-col>
+        </b-form-row>
+      </b-form>
+      <div v-if="showMessage"
+            class="mb-3"
+            style="color: red;">Nothing has changed.  All fields contain their initial values.</div>
+      <div style="display: flex; justify-content: flex-end; width: 100%">
+        <b-btn class="btn-secondary mr-2" @click="cancel">Cancel</b-btn>
+        <b-btn v-if="editedFields.length === 0"
+               class="btn-primary disabled"
+               @click="showMessage=true">Submit</b-btn>
+        <b-btn v-else-if="editedFields.length > 0"
+               class="btn-primary"
+               @click="submit">Submit</b-btn>
+      </div>
+    </div>
+  </b-modal>
+</template>
+
+<script>
+  import { mapActions, mapMutations, mapState, mapGetters } from 'vuex'
+  import moment from 'moment'
+  import DatePicker from 'vue2-datepicker'
+
+  export default {
+    name: "EditGroupExamBookingModal",
+    components: { DatePicker },
+    props: ['exam', 'resetExam'],
+    data () {
+      return {
+        invigilator_id: '',
+        date: '',
+        time: '',
+        offsite_location: '',
+        editedFields: [],
+        showMessage: false,
+        itemCopy: {},
+      }
+    },
+    computed: {
+      ...mapGetters(['role_code']),
+      ...mapState({
+        showModal: state => state.showEditGroupBookingModal,
+        invigilators: state => state.invigilators,
+      }),
+      invigilatorOptions() {
+        if (this.invigilators && this.invigilators.length > 0) {
+          return this.invigilators.map( inv =>
+            ({text: inv.invigilator_name, value: inv.invigilator_id})
+          )
+        }
+        return []
+      },
+      modalVisible: {
+        get() {
+          return this.showModal
+        },
+        set(e) {
+          this.toggleEditGroupBookingModal(e)
+        }
+      }
+    },
+    methods: {
+      ...mapActions(['getBookings', 'getExams', 'putRequest']),
+      ...mapMutations(['toggleEditGroupBookingModal']),
+      cancel() {
+        this.toggleEditGroupBookingModal(false)
+        this.reset()
+        this.resetExam()
+      },
+      checkDate(e) {
+        this.showMessage = false
+        let date = new moment(this.itemCopy.booking.start_time).format('ddmmyyyy').toString()
+        let newDate = new moment(e).format('ddmmyyyy').toString()
+        if (newDate === date) {
+          if (this.editedFields.includes('date')) {
+            let i = this.editedFields.indexOf('date')
+            this.editedFields.splice(i,1)
+          }
+        }
+        if (newDate !== date) {
+          if (!this.editedFields.includes('date')) {
+            this.editedFields.push('date')
+          }
+        }
+      },
+      checkTime(e) {
+        this.showMessage = false
+        let time = new moment(this.itemCopy.booking.start_time).format('HH:mm').toString()
+        let newTime = new moment(e).format('HH:mm').toString()
+        if (newTime === time) {
+          if (this.editedFields.includes('time')) {
+            let i = this.editedFields.indexOf('time')
+            this.editedFields.splice(i,1)
+          }
+        }
+        if (newTime !== time) {
+          if (!this.editedFields.includes('time')) {
+            this.editedFields.push('time')
+          }
+        }
+      },
+      checkInput(e) {
+        let { name } = e.target
+        let { value } = e.target
+
+        this.showMessage = false
+        if (name === 'offsite_location') {
+          if (value !== this.itemCopy[name]) {
+            if (!this.editedFields.includes(e.target.name)) {
+              this.editedFields.push(e.target.name)
+            }
+            this[e.target.name] = e.target.value
+            return
+          }
+          if (value === this.itemCopy[name]) {
+            if (this.editedFields.includes(e.target.name)) {
+              let i = this.editedFields.indexOf(e.target.name)
+              this.editedFields.splice(i, 1)
+            }
+            this[e.target.name] = e.target.value
+            return
+          }
+        }
+        value = parseInt(value)
+        if (value !== this.itemCopy.booking[name]) {
+          if (!this.editedFields.includes(e.target.name)) {
+            this.editedFields.push(e.target.name)
+          }
+          this[e.target.name] = e.target.value
+          return
+        }
+        if (value == this.itemCopy.booking[name]) {
+          if (this.editedFields.includes(e.target.name)) {
+            let i = this.editedFields.indexOf(e.target.name)
+            this.editedFields.splice(i, 1)
+          }
+          this[e.target.name] = e.target.value
+          return
+        }
+      },
+      submit() {
+        let edits = this.editedFields
+        let putRequests = []
+
+        let bookingChanges = {}
+        if (edits.includes('time') || edits.includes('date') || edits.includes('invigilator_id')) {
+          let baseDate = new moment(this.itemCopy.booking.start_time).format('YYYY-MM-DD').toString()
+          let baseTime = new moment(this.itemCopy.booking.start_time).format('HH:mm:ssZ').toString()
+          if (edits.includes('time')) {
+            baseTime = new moment(this.time).format('HH:mm:ssZ').toString()
+          }
+          if (edits.includes('date')) {
+            baseDate = new moment(this.date).format('YYYY-MM-DD').toString()
+          }
+          let start =  moment(baseDate + 'T' + baseTime)
+          let end = start.clone().add(parseInt(this.itemCopy.exam_type.number_of_hours), 'h')
+          bookingChanges['start_time'] = start.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+          bookingChanges['end_time'] = end.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+          if (this.invigilator_id) {
+            bookingChanges['invigilator_id'] = this.invigilator_id
+          }
+          putRequests.push({url:`/bookings/${this.itemCopy.booking.booking_id}/`, data: bookingChanges})
+        }
+        let examChanges = {}
+        if (edits.includes('offsite_location')) {
+          examChanges['offsite_location'] = this.offsite_location
+          putRequests.push({url:`/exams/${this.itemCopy.exam_id}/`, data: examChanges})
+        }
+        let promises = []
+        putRequests.forEach( put => {
+          promises.push(this.putRequest(put))
+        })
+        Promise.all(promises).then( () => {
+          this.getBookings().then( () => {
+            this.getExams().then( () => {
+              this.cancel()
+            })
+          })
+        })
+      },
+      setValues() {
+        let tempItem = Object.assign({}, this.exam)
+        this.time = tempItem.booking.start_time
+        this.date = tempItem.booking.start_time
+        this.offsite_location = tempItem.offsite_location
+        this.invigilator_id = tempItem.booking.invigilator_id
+        this.editedFields = []
+        this.itemCopy = tempItem
+      },
+      reset() {
+        let tempItem = null
+        this.time = null
+        this.date = null
+        this.offsite_location = null
+        this.invigilator_id = null
+        this.itemCopy = {}
+        this.editedFields = []
+      }
+    },
+  }
+</script>
+
+<style scoped>
+  .id-grid-1st-col {
+    margin-left: auto;
+    margin-right: 20px;
+  }
+  .id-grid-1st-col {
+    grid-column: 1 / span 2;
+    margin-right: 20px;
+  }
+</style>

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -40,17 +40,14 @@
         <b-btn-group horizontal class="ml-2 pt-2">
           <b-btn value="both"
                  size="sm"
-
                  :pressed="groupFilter==='both'"
                  @click="groupFilter='both'"><span class="mx-2">Both</span></b-btn>
           <b-btn value="unbooked"
                  size="sm"
-
                  :pressed="groupFilter==='individual'"
                  @click="groupFilter='individual'">Individual</b-btn>
           <b-btn value="booked"
                  size="sm"
-
                  :pressed="groupFilter==='group'"
                  @click="groupFilter='group'">Group</b-btn>
         </b-btn-group>
@@ -108,13 +105,20 @@
                                style="padding: -2px; margin: -2px; font-size: 1rem; color: dimgray"/>
           </template>
           <b-dropdown-item size="sm"
-                           @click.stop="editInfo(row.item, row.index)">Edit Row</b-dropdown-item>
+                           @click.stop="editInfo(row.item, row.index)">Edit Exam</b-dropdown-item>
           <b-dropdown-item size="sm"
                            @click.stop="returnExamInfo(row.item, row.index)">Return Exam</b-dropdown-item>
-          <b-dropdown-item v-if=row.item.booking
+          <b-dropdown-item v-if="row.item.booking"
                            size="sm"
-                           @click="updateBookingRoute(row.item, row.index)">Edit Booking</b-dropdown-item>
-          <b-dropdown-item v-else-if=!row.item.booking
+                           @click="updateBookingRoute(row.item)">
+            <template v-if="row.item.offsite_location">
+              {{ row.item.booking.invigilator_id ? 'Reschedule' : 'Schedule' }}
+            </template>
+            <template v-if="!row.item.offsite_location">
+              {{ row.item.booking ? 'Reschedule' : 'Schedule' }}
+            </template>
+          </b-dropdown-item>
+          <b-dropdown-item v-else-if="!row.item.booking"
                            size="sm"
                            @click="addBookingRoute(row.item, row.index)">Add Booking</b-dropdown-item>
         </b-dropdown>
@@ -123,6 +127,7 @@
     </div>
     <EditExamModal v-if="showEditExamModal"></EditExamModal>
     <ReturnExamModal v-if="showReturnExamModalVisible"></ReturnExamModal>
+    <EditGroupExamBookingModal :exam="item" :resetExam="resetEditedExam" />
   </div>
 </template>
 
@@ -133,23 +138,23 @@
   import moment from 'moment'
   import SuccessExamAlert from './success-exam-alert'
   import FailureExamAlert from './failure-exam-alert'
+  import EditGroupExamBookingModal from './edit-group-exam-modal'
 
   export default {
     name: "ExamInventoryTable",
-    components: { EditExamModal, ReturnExamModal, SuccessExamAlert, FailureExamAlert },
+    components: { EditGroupExamBookingModal, EditExamModal, ReturnExamModal, SuccessExamAlert, FailureExamAlert },
     props: ['mode'],
     mounted() {
-      this.getBookings().then(bookings => {
-        this.events = bookings
-      })
+      this.getInvigilators()
+      this.getBookings().then( () => { this.getExams() })
       this.getWidth()
-      this.getExams()
       this.$nextTick(function() {
         window.addEventListener('resize', () => { this.getWidth() })
       })
     },
     data() {
       return {
+        item: null,
         tableStyle: null,
         expiryFilter: 'all',
         bookedFilter: 'both',
@@ -266,7 +271,7 @@
 
     },
     methods: {
-      ...mapActions(['getExams', 'getBookings']),
+      ...mapActions(['getExams', 'getBookings', 'getInvigilators']),
       ...mapMutations([
         'navigationVisible',
         'setSelectedExam',
@@ -275,6 +280,7 @@
         'toggleScheduling',
         'toggleSchedulingIndicator',
         'toggleEditExamModalVisible',
+        'toggleEditGroupBookingModal',
         'setEditExamInfo',
         'toggleReturnExamModalVisible',
         'setReturnExamInfo',
@@ -329,10 +335,16 @@
         this.setReturnExamInfo(item)
       },
       updateBookingRoute(item) {
-        let bookingRoute = '/booking/'
-        let rowDate = moment(item.booking.start_time).format('YYYY-MM-DD')
-        let dateConcat = bookingRoute.concat(rowDate)
-        this.$router.push(dateConcat)
+        if (item.offsite_location) {
+          this.item = item
+          this.toggleEditGroupBookingModal(true)
+          return
+        }
+        let route = '/booking/' + moment(item.booking.start_time).format('YYYY-MM-DD').toString()
+        this.$router.push(route)
+      },
+      resetEditedExam() {
+        this.item = {}
       },
       addBookingRoute(item) {
         let bookingRoute = '/booking/?schedule=true'
@@ -343,7 +355,7 @@
         this.toggleExamInventoryModal(false)
         this.toggleScheduling(true)
         this.toggleSchedulingIndicator(true)
-      }
+      },
     },
   }
 </script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -28,6 +28,7 @@ import {
   faRegistered
 } from '@fortawesome/free-regular-svg-icons'
 import {
+  faClock,
   faAngleLeft,
   faAngleRight,
   faBars,
@@ -48,6 +49,7 @@ import VDragged from 'v-dragged'
 
 Vue.use(VDragged)
 library.add(
+  faClock,
   faAngleLeft,
   faAngleRight,
   faBars,

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -281,6 +281,7 @@ export const store = new Vuex.Store({
     editedBookingOriginal: null,
     editExamFailure: false,
     editExams: [],
+    editedGroupBooking: null,
     editExamSuccess: false,
     examAlertMessage: '',
     examEditSuccessMessage: '',
@@ -334,6 +335,7 @@ export const store = new Vuex.Store({
     showBookingModal: false,
     showCalendarControls: true,
     showEditBookingModal: false,
+    showEditGroupBookingModal: false,
     showEditExamModal: false,
     showExamInventoryModal: false,
     showFeedbackModal: false,
@@ -635,6 +637,16 @@ export const store = new Vuex.Store({
       })
     },
     
+    putRequest(context, payload) {
+      return new Promise((resolve, reject) => {
+        Axios(context).put(payload.url, payload.data).then( () => {
+          resolve()
+        }).catch( () => {
+          reject()
+        })
+      })
+    },
+    
     putBooking(context, payload) {
       return new Promise((resolve, reject) => {
         Axios(context).put(`/bookings/${payload.id}/`, payload.changes).then(resp => {
@@ -699,10 +711,7 @@ export const store = new Vuex.Store({
             booking.end = b.end_time
             booking.title = b.booking_name
             booking.id = b.booking_id
-            let exam = context.state.exams.find(ex => parseInt(ex.booking_id) == parseInt(b.booking_id)) || null
-            if (exam !== null && exam.length >= 1) {
-              booking.exam = exam
-            }
+            booking.exam = context.state.exams.find(ex => ex.booking_id == b.booking_id) || false
           calendarEvents.push(booking)
           })
           context.commit('setEvents', calendarEvents)
@@ -2348,7 +2357,7 @@ export const store = new Vuex.Store({
 
     toggleNonITAExamModal: (state, payload) => state.nonITAExam = payload,
 
-    toggleEditExamModalVisible: (state, payload) => state.showEditExamModalVisible = payload,
+    toggleEditExamModalVisible: (state, payload) => state.showEditExamModal = payload,
 
     toggleReturnExamModalVisible: (state, payload) => state.showReturnExamModalVisible = payload,
 
@@ -2416,5 +2425,12 @@ export const store = new Vuex.Store({
     toggleSelectInvigilatorModal: (state, payload) => state.showSelectInvigilatorModal = payload,
     
     setEvents: (state, payload) => state.calendarEvents = payload,
+    
+    setInventoryEditedBooking(state, booking) {
+      let bookingCopy = Object.assign({}, booking)
+      state.editedBooking = bookingCopy
+    },
+  
+    toggleEditGroupBookingModal: (state, payload) => state.showEditGroupBookingModal = payload,
   }
 })


### PR DESCRIPTION
'Edit Booking' now has logic to determine exam type: individual exams are still directed to the booking calendar for editing, group exams however, now launch an Edit Group Exam Booking modal.  For GA/CSR-LIAISONs, GAs and GA-designates, the modal displays the option to edit Date, Time, Location and Invigilator (as well as set Invigilator initially).  For CSRs, the modal only shows the option to edit (or set) invigilators.