### PR TITLE
Scheduling Appointments - Models and Schemas

### DIFF
--- a/api/app/models/bookings/__init__.py
+++ b/api/app/models/bookings/__init__.py
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.'''
 
+from app.models.bookings.appointments import Appointment
 from app.models.bookings.base import Base
 from app.models.bookings.booking import Booking
 from app.models.bookings.exam import Exam

--- a/api/app/models/bookings/appointments.py
+++ b/api/app/models/bookings/appointments.py
@@ -1,0 +1,37 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+from app.models.bookings import Base
+from qsystem import db
+from sqlalchemy_utc import UtcDateTime
+
+
+class Appointment(Base):
+
+    appointment_id = db.Column(db.Integer, primary_key=True, autoincrement=True, nullable=False)
+    office_id = db.Column(db.Integer, db.ForeignKey("office.office_id"), nullable=False)
+    start_time = db.Column(UtcDateTime, nullable=False)
+    end_time = db.Column(UtcDateTime, nullable=False)
+    category = db.Column(db.String(255), nullable=False)
+    checked_in_time = db.Column(UtcDateTime, nullable=True)
+    comments = db.Column(db.String(255), nullable=True)
+
+    office = db.relationship("Office")
+
+    def __repr__(self):
+        return '<Appointment ID: (name={self.appointment_id!r})>'.format(self=self)
+
+    def __init__(self, **kwargs):
+        super(Appointment, self).__init__(**kwargs)
+

--- a/api/app/schemas/bookings/__init__.py
+++ b/api/app/schemas/bookings/__init__.py
@@ -17,5 +17,6 @@ from app.schemas.bookings.exam_type_schema import ExamTypeSchema
 from app.schemas.bookings.room_schema import RoomSchema
 from app.schemas.bookings.booking_schema import BookingSchema
 from app.schemas.bookings.exam_schema import ExamSchema
+from app.schemas.bookings.appointment_schema import AppointmentSchema
 
 

--- a/api/app/schemas/bookings/appointment_schema.py
+++ b/api/app/schemas/bookings/appointment_schema.py
@@ -1,0 +1,36 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+from marshmallow import fields
+import toastedmarshmallow
+from app.models.bookings import Appointment
+from app.schemas.theq import OfficeSchema
+from qsystem import ma
+
+
+class AppointmentSchema(ma.ModelSchema):
+
+    class Meta:
+        model = Appointment
+        jit = toastedmarshmallow.Jit
+
+    appointment_id = fields.Int(dump_only=True)
+    office_id = fields.Int()
+    start_time = fields.DateTime()
+    end_time = fields.DateTime()
+    category = fields.String()
+    checked_in_time = fields.DateTime()
+    comments = fields.String()
+
+    office = fields.Nested(OfficeSchema())


### PR DESCRIPTION
CSRs were determined to need the ability to schedule smaller appointments on the bookings calendar feature for reasons other than exams. For this, an appointments model and schema were developed such that a separate calendar feature can be developed, separate from the exam bookings calendar. Future development will include GET, POST, PUT and DELETE http methods, as well as updates to postman tests and swagger api spec.