### PR TITLE
Remove Ability to Drag For Events on Bookings Calendar

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -72,6 +72,8 @@
   import { adjustColor } from '../store/helpers'
   import OfficeDropDownFilter from '../exams/office-dropdown-filter'
 
+  var urlParams = new URLSearchParams(window.location.search)
+
   export default {
     name: 'Calendar',
     components: {
@@ -179,9 +181,13 @@
         'showSchedulingIndicator',
       ]),
       config() {
-        let setup = this.setup
-        setup.selectable = true
-        return setup
+        let calSetup = this.setup
+        if(urlParams.has('schedule')){
+          calSetup.selectable = true
+        }else{
+          calSetup.selectable = false
+        }
+        return calSetup
       },
       adjustment() {
         if (this.showSchedulingIndicator) {
@@ -485,11 +491,6 @@
           this.$refs.bookingcal.fireMethod('changeView', 'agendaDay')
           this.goToDate(this.$route.params.date)
         }
-        if(this.$route.params.schedule == true) {
-          this.$refs.bookingcal.fireMethod('changeView', 'agendaWeek')
-          this.toggleOffsite(false)
-          this.options({name: 'selectable', value: true})
-      }
       },
     }
   }

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -364,7 +364,7 @@
         return new moment(d).format('h:mm a')
       },
       addBookingRoute(item) {
-        let bookingRoute = '/booking/?schedule=true'
+        let bookingRoute = '/booking/?schedule=1'
         this.$router.push(bookingRoute)
         this.navigationVisible(false)
         this.setSelectedExam(item)


### PR DESCRIPTION
During demo testing, it was found that the bookings calendar was selectable by default, allowing users to drag events onto the calendar without having an event in queue to be placed on the calendar. This was not required functionality on the calendar, and was deemed a bug. This bug was fixed by how the calendar.vue file looks for URL parameters, and how it sets the selectable option to true or false.