### PR TITLE
Created new edit exams modal and form

### DIFF
--- a/frontend/src/agenda/agenda.vue
+++ b/frontend/src/agenda/agenda.vue
@@ -33,8 +33,8 @@
               </template>
 
               <template slot="materials" slot-scope="row">
-                <span v-if="!row.item.exam.exam_received" style="color: red;">No</span>
-                <span v-if="row.item.exam.exam_received">Yes</span>
+                <span v-if="!row.item.exam.exam_received_date" style="color: red;">No</span>
+                <span v-if="row.item.exam.exam_received_date">Yes</span>
               </template>
 
               <template slot="invigilator" slot-scope="row">

--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -304,7 +304,6 @@
         if (this.scheduling || this.schedulingOther || event.resourceId === '_offsite') {
           return
         }
-        console.log(event)
         if (view.name === 'listYear') {
           this.goToDate(event.start)
           this.agendaDay()

--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -492,6 +492,11 @@
         }
         let changes = {}
         if (!this.start.isSame(this.event.start)) {
+          if (this.examAssociated) {
+            if (this.start.isAfter(this.event.exam.expiry_date)) {
+              this.message = 'Selected date/time is '
+            }
+          }
           if (moment().isAfter(this.start)) {
             this.message = 'Selected date/time is is in the past. Press Reschedule and pick a new time.'
             return

--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -206,7 +206,6 @@ export const ExamReceivedQuestion = Vue.component('exam-received-question', {
   methods: {
     ...mapMutations(['captureExamDetail', 'toggleIndividualCaptureTabRadio']),
       selectRecdDate(e) {
-        console.log(e)
         this.handleInput({
           target: {
             name: 'exam_received_date',
@@ -279,7 +278,7 @@ export const DateQuestion = Vue.component('date-question', {
     <b-row no-gutters>
       <b-col cols="11">
         <b-form-group>
-          <label class="mr-3">
+          <label>
             {{ addITAExamModal.setup == 'group' ? 'Exam Date' : 'Expiry Date' }}
             <span v-if="error" style="color: red">{{ validationObj[q.key].message }}</span>
           </label>
@@ -316,7 +315,7 @@ export const TimeQuestion = Vue.component('time-question', {
     <b-row no-gutters>
       <b-col cols="11">
         <b-form-group>
-          <label class="mr-3">
+          <label>
             Exam Time
             <span v-if="error" style="color: red">{{ validationObj[q.key].message }}</span>
           </label>
@@ -349,9 +348,6 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
         return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
       }
       if(this.addITAExamModal.setup === 'individual' && this.nonITAExam) {
-        //this.examTypes.forEach(type => {
-          //console.log(type)
-        //})
         return this.examTypes.filter(type  => type.ita_ind === 0)
       }
       if (this.addITAExamModal.setup === 'group') {

--- a/frontend/src/exams/add-exam-form-modal.vue
+++ b/frontend/src/exams/add-exam-form-modal.vue
@@ -234,9 +234,11 @@
       },
       initialize() {
         this.captureExamDetail({key:'notes', value: ''})
-        let d = new Date()
-        let today = moment(d).format('YYYY-MM-DD')
-        this.captureExamDetail({key:'exam_received_date', value: today})
+        if (this.addITAExamModal.setup !== 'group') {
+          let d = new Date()
+          let today = moment(d).format('YYYY-MM-DD')
+          this.captureExamDetail({ key: 'exam_received_date', value: today })
+        }
         this.unSubmitted = true
         this.submitMsg = ''
       },

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -1,11 +1,15 @@
 <template v-if="showExams">
-  <div>
-    <b-form inline>
-      <b-button variant="primary" class="mr-1" @click="clickAddIndividual">Add Individual Exam</b-button>
-      <b-button variant="primary" class="mr-1" @click="clickAddNonITA">Add Non-ITA Exam</b-button>
-      <b-button variant="primary" class="mx-2" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
-      <b-button variant="primary" class="mr-1" @click="clickGenFinReport">Generate Financial Report</b-button>
-    </b-form>
+  <div style="display: flex; justify-content: flex-start; width: 100%">
+    <div style="flex-grow: 12">
+      <b-form inline>
+        <b-button variant="primary" class="mr-1" @click="clickAddIndividual">Add Individual Exam</b-button>
+        <b-button variant="primary" class="mr-1" @click="clickAddNonITA">Add Non-ITA Exam</b-button>
+        <b-button variant="primary" v-if="liaison" @click="clickAddGroup">Add Group Exam</b-button>
+      </b-form>
+    </div>
+    <div style="flex-grow: 1">
+      <b-button variant="primary" @click="clickGenFinReport">Generate Financial Report</b-button>
+    </div>
     <AddExamFormModal />
     <FinancialReportModal />
   </div>

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -1,148 +1,362 @@
 <template>
-  <b-modal v-model="modal"
+  <b-modal v-model="showModal"
            :no-close-on-backdrop="true"
-           hide-ok
            hide-header
-           hide-cancel
-           @hidden="ok"
-           @ok="submit"
+           hide-footer
+           @hidden="reset"
+           @shown="populateForm"
            size="md">
-    <b-container style="font-size:1.1rem; border:1px solid lightgrey; border-radius: 10px" class="mb-2 pb-3" fluid>
-      <b-row>
-        <b-col>
-          <h3>Edit Exam Information Form</h3>
-        </b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Event ID:</label></b-col>
-        <b-col sm="6"><b-form-input id="eventIDInput" type="text" v-model=fields.event_id></b-form-input></b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Exam Name:</label></b-col>
-        <b-col sm="6"><b-form-input id="examNameInput" type="text" v-model=fields.exam_name></b-form-input></b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Exam Methods:</label></b-col>
-        <b-col sm="6">
-          <select class="form-control" name="examMethod" v-model=selectedMethod>
-            <option v-for="examMethod in examMethodOptions" :value="examMethod.value">{{ examMethod.value }}</option>
-          </select>
-        </b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Expiry Date:</label></b-col>
-        <b-col sm="6"><b-form-input id="expiryDate" type="date" v-model=expiryDate></b-form-input></b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Exam Received:</label></b-col>
-        <b-col sm="6">
-          <select class="form-control" name="examReceived" v-model=selectedReceived>
-            <option v-for="received in examReceivedOptions" :value="received.value">{{ received.value }}</option>
-          </select>
-        </b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Student Name:</label></b-col>
-        <b-col sm="6"><b-form-input id="studentName" type="text" v-model=fields.examinee_name></b-form-input></b-col>
-      </b-row>
-      <b-row class="my-1">
-        <b-col sm="4"><label>Notes:</label></b-col>
-        <b-col sm="6"><b-form-input id="examNotes" type="text" v-model="fields.notes"></b-form-input></b-col>
-      </b-row>
-    </b-container>
+    <div v-if="exam">
+      <b-table v-show="false"
+               :items="offices"
+               :fields="{key: 'office_name'}"
+               :filter="search"
+               @filtered="getFilteredOffices" />
+      <span style="font-size: 1.4rem; font-weight: 600;">Edit Exam</span>
+      <b-form v-if="showAllFields">
+        <b-form-row v-if="role_code === 'LIAISON'">
+          <b-col>
+            <b-form-group>
+              <label class="my-0">Office (Start typing below to search or enter Office Number )</label>
+              <div>
+                <b-form-input id="office_name"
+                              type="text"
+                              class="less-10-mb"
+                              :value="officeSearch"
+                              @focus.native="officeSearchOnFocus"
+                              @blur.native="officeSearchOnBlur"
+                              @input.native="handleOfficeInput" />
+              </div>
+              <div :class="officeDropClass"
+                   style="border: 1px solid grey">
+                <template v-for="office in officeChoices">
+                  <b-dropdown-item-button v-on:click.prevent="handleOfficeDropClick"
+                                          :name="office.office_name"
+                                          :value="office.office_number"
+                                          :id="office.office_id">{{ office.office_name }}</b-dropdown-item-button>
+                </template>
+              </div>
+            </b-form-group>
+          </b-col>
+          <b-col cols="2">
+            <b-form-group>
+              <label class="my-0">Office #</label>
+              <b-form-input id="office_id"
+                            type="number"
+                            class="less-10-mb"
+                            :value="office_number"
+                            @input.native="handleOfficeNumberInput" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+          <b-col cols="6">
+            <b-form-group>
+              <label class="my-0">Event ID</label>
+              <b-form-input id="event_id"
+                            type="text"
+                            class="less-10-mb"
+                            v-model="fields.event_id" />
+            </b-form-group>
+          </b-col>
+          <b-col cols="6">
+            <b-form-group>
+              <label class="my-0">Exam Method</label><br>
+              <b-select id="exam_method"
+                        class="less-10-mb"
+                        v-model="fields.exam_method"
+                        :options="methodOptions" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+            <b-col>
+              <b-form-group>
+                <label class="my-0">Exam Type</label><br>
+                <div @click="handleExamInputClick">
+                  <b-input read-only
+                           class="less-15-mb"
+                           :value="examInputText"
+                           placeholder="click here to see options"
+                           :style="examInputStyle" />
+                </div>
+                <div :class="examTypeDropClass"
+                     style="border: 1px solid grey"
+                     @click="handleExamInputClick">
+                  <template v-for="type in examTypeDropItems">
+                    <b-dd-header v-if="type.header"
+                                 :style="{backgroundColor: type.exam_color}"
+                                 :class="type.class">{{ type.exam_type_name }}</b-dd-header>
+                    <b-dd-item v-else :style="{backgroundColor: type.exam_color}"
+                               @click="handleExamDropClick"
+                               :value="type.exam_type_id"
+                               :id="type.exam_type_id"
+                               :class="type.class">{{ type.exam_type_name }}</b-dd-item>
+                  </template>
+                </div>
+              </b-form-group>
+            </b-col>
+          </b-form-row>
+        <b-form-row>
+          <b-col>
+            <b-form-group>
+              <label class="mb-0 mt-1">Exam Name</label>
+              <b-form-input id="exam_name" type="text"
+                            class="less-10-mb"
+                            v-model="fields.exam_name" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+          <b-col :col="!this.fields.exam_received_date" :cols="this.exam_received ? 3 : '' ">
+            <b-form-group>
+              <label class="my-0">Exam Received?</label>
+              <b-select id="exam_received"
+                        v-model="exam_received"
+                        @input="updateExamReceived"
+                        class="less-10-mb"
+                        :options="examReceivedOptions" />
+            </b-form-group>
+          </b-col>
+          <b-col v-if="exam_received">
+            <b-form-group>
+              <label class="my-0">Received Date</label><br>
+              <DatePicker v-model="fields.exam_received_date"
+                          id="exam_received_date"
+                          input-class="form-control"
+                          class="w-100 my-0 less-10-mb"
+                          lang="en"/>
+            </b-form-group>
+          </b-col>
+          <b-col v-if="examType === 'group'" col>
+            <b-form-group>
+              <label class="my-0"># of Writers</label><br>
+              <b-input v-model="fields.number_of_students"
+                       id="number_of_students" />
+            </b-form-group>
+          </b-col>
+          <b-col class="w-100" v-if="examType === 'individual'">
+            <b-form-group>
+              <label class="my-0">Expiry Date</label><br>
+              <DatePicker v-model="fields.expiry_date"
+                          id="exam_expiry"
+                          input-class="form-control"
+                          class="w-100 less-10-mb"
+                          lang="en"/>
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row v-if="examType === 'individual' || examType === 'other'">
+          <b-col>
+            <b-form-group>
+              <label class="my-0">Writer's Name</label>
+              <b-form-input id="examinee_name"
+                            class="less-10-mb"
+                            type="text"
+                            v-model="fields.examinee_name" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+          <b-col>
+            <b-form-group>
+              <label class="my-0">Notes</label><br>
+              <b-textarea id="notes" v-model="fields.notes" :rows="2" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+      </b-form>
+      <b-form v-if="!showAllFields">
+        <b-form-row>
+          <b-col class="mb-2">
+            <div class="q-info-display-grid-container">
+              <div class="q-id-grid-outer">
+                <div class="id-grid-1st-col w-100 pr-2">
+                  <strong>Exam Details:</strong>
+                </div>
+                <div class="id-grid-1st-col w-100 pr-2">
+                  <div style="display: flex; justify-content: space-between; width: 100%">
+                    <div>Exam:</div>
+                    <div>{{ this.exam.exam_name }}</div>
+                  </div>
+                </div>
+                <div class="pl-2">Event ID: </div>
+                <div class="q-id-grid-2nd-col">{{ this.exam.event_id }}</div>
+                <div class="id-grid-1st-col w-100 pr-2">
+                  <div style="display: flex; justify-content: space-between; width: 100%">
+                    <div>Type:</div>
+                    <div :style="{color: exam.exam_type.exam_color}">{{ exam.exam_type.exam_type_name }}</div>
+                  </div>
+                </div>
+                <div class="pl-2">Method: </div>
+                <div class="q-id-grid-2nd-col">{{ this.exam.exam_method }}</div>
+              </div>
+            </div>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+          <b-col>
+            <b-form-group>
+              <label class="my-0">Exam Received?</label>
+              <b-select id="exam_received"
+                        class="less-10-mb"
+                        @input="updateExamReceived"
+                        :options="examReceivedOptions"
+                        v-model="exam_received" />
+            </b-form-group>
+          </b-col>
+          <b-col v-if="exam_received" cols="6">
+            <b-form-group>
+              <label class="my-0">Date Received</label><br>
+              <DatePicker v-model="fields.exam_received_date"
+                          id="exam_received_date"
+                          input-class="form-control"
+                          class="w-100 my-0 less-10-mb"
+                          lang="en"/>
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+        <b-form-row>
+          <b-col>
+            <b-form-group>
+              <label class="my-0">Notes</label><br>
+              <b-textarea id="notes" v-model="fields.notes" :rows="2" />
+            </b-form-group>
+          </b-col>
+        </b-form-row>
+      </b-form>
+      <div v-if="showMessage"
+           class="mb-3"
+           style="color: red;">{{ this.message }}</div>
+      <div style="display: flex; justify-content: flex-end; width: 100%">
+        <b-btn class="btn-secondary mr-2" @click="toggleEditExamModal(false)">Cancel</b-btn>
+        <b-btn v-if="!allowSubmit()"
+               class="btn-primary disabled"
+               @click="setMessage">Submit</b-btn>
+        <b-btn v-else-if="allowSubmit()"
+               class="btn-primary"
+               @click="submit">Submit</b-btn>
+      </div>
+    </div>
   </b-modal>
 </template>
 
 <script>
-  import { mapActions, mapMutations, mapState } from 'vuex'
+  import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
+  import DatePicker from 'vue2-datepicker'
   import moment from 'moment'
+  import Vue from 'vue'
+
   export default {
     name: "EditExamModal",
-    mounted() {
-      this.selectedMethod = this.fields.exam_method;
-      this.expiryDate = moment(this.fields.expiry_date).format('YYYY-MM-DD');
-      if(this.fields.exam_received === 0) {
-        this.selectedReceived = 'No';
-      }else if (this.fields.exam_received === 1){
-        this.selectedReceived = 'Yes';
-      }
-    },
+    components: { DatePicker },
+    props: ['examRow', 'resetExam'],
     data () {
       return {
-        selectedMethod: '',
-        examMethodOptions: [
-          { id: 'paper', value: 'paper'},
-          { id: 'online', value: 'online'}
-        ],
-        expiryDate:'',
-        selectedReceived: '',
+        clickedMenu: false,
         examReceivedOptions: [
-          { id: 0, value: 'No' },
-          { id: 1, value: 'Yes' }
+          { value: false, text: 'No' },
+          { value: true, text: 'Yes' },
         ],
-        noBooking: true
+        fields: {},
+        message: '',
+        methodOptions: [
+          { text: 'paper', value: 'paper'},
+          { text: 'online', value: 'online'},
+        ],
+        exam_received: false,
+        office_number: null,
+        officeChoices: [],
+        showMessage: false,
+        showSearch: false,
+        searching: false,
+        search: '',
       }
     },
-    methods: {
-      ...mapActions([
-        'putExamInfo',
-        'putBookingInfo',
-        'getExams',
-        'getBookings'
-      ]),
-      ...mapMutations([
-        'toggleEditExamModal',
-        'setEditExamSuccess',
-        'setEditExamFailure'
-      ]),
-      ok() {
-        this.toggleEditExamModal(false);
-        this.setEditExamSuccess(false);
-        this.setEditExamFailure(false);
-      },
-      cancel() {
-        this.toggleEditExamModal(false);
-        this.selectedMethod = '';
-        this.expiryDate = '';
-        this.selectedReceived = '';
-      },
-      submit() {
-        this.setEditExamSuccess(false)
-        this.setEditExamFailure(false)
-        this.selectedExam.exam_id = this.fields.exam_id;
-        if (this.selectedReceived === 'No') {
-          this.selectedReceived = 0;
-        }else {
-          this.selectedReceived = 1;
-        }
-        let submit_exam = {
-          exam_id: this.selectedExam.exam_id,
-          event_id: this.fields.event_id,
-          exam_name: this.fields.exam_name,
-          exam_method: this.selectedMethod,
-          expiry_date: this.expiryDate,
-          exam_received: this.selectedReceived,
-          examinee_name: this.fields.examinee_name,
-          notes: this.fields.notes
-        };
-        this.putExamInfo(submit_exam);
-        if(this.editExamFailure === false){
-          this.setEditExamFailure(false)
-        }
-        this.getExams()
-        console.log(this.editExamSuccess)
-      },
-    },
     computed: {
-      ...mapState({
-        showEditExamModal: state => state.showEditExamModal,
-        fields: state => state.editExams,
-        selectedExam: state => state.selectedExam,
-        selectedBooking: state => state.selectedBooking,
-        editExamSuccess: state => state.editExamSuccess,
-        editExamFailure: state => state.editExamFailure
-      }),
-      modal: {
+      ...mapGetters(['exam_object_id', 'role_code']),
+      ...mapState(['editExamFailure', 'editExamSuccess', 'examTypes', 'offices', 'showEditExamModal',]),
+      exam() {
+        if (Object.keys(this.examRow).length > 0) {
+          return this.examRow
+        }
+        return false
+      },
+      examInputStyle() {
+        if (this.examObject) {
+          let { exam_color } = this.examObject
+          return { border: `1px solid ${exam_color}`, boxShadow: `inset 0px 0px 0px 3px ${exam_color}`, }
+        }
+        return ''
+      },
+      examInputText() {
+        if (this.examObject) {
+          return this.examObject.exam_type_name
+        }
+        return ''
+      },
+      examObject() {
+        if (this.fields && this.fields.exam_type_id) {
+          return this.exam_object_id(this.fields.exam_type_id)
+        }
+        return ''
+      },
+      examType() {
+        if (this.exam && this.exam.exam_type && this.exam.exam_type.ita_ind) {
+          if (this.exam.offsite_location) {
+            return 'group'
+          }
+          return 'individual'
+        }
+        return 'other'
+      },
+      examTypeDropClass() {
+        if (!this.clickedMenu) {
+          return 'dropdown-menu'
+        }
+        if (this.clickedMenu) {
+          return 'dropdown-menu show py-0 my-0 w-100'
+        }
+      },
+      examTypeDropItems() {
+        if (this.exam) {
+          if (this.exam.offsite_location) {
+            return this.examTypes.filter(type => type.exam_type_name.includes('Group'))
+          }
+          if (!this.exam.offsite_location) {
+            return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
+          }
+        }
+        return []
+      },
+      officeDropClass() {
+        if (!this.showSearch) {
+          return 'dropdown-menu'
+        }
+        if (this.showSearch) {
+          return 'dropdown-menu show py-0 my-0 w-100'
+        }
+      },
+      officeSearch() {
+        if (!this.searching && this.office_number) {
+          return this.offices.find(office=>office.office_number == this.office_number).office_name
+        }
+        return this.search
+      },
+      showAllFields() {
+        if (this.exam) {
+          if (!this.exam.offsite_location) {
+            return true
+          }
+          if (this.exam.offsite_location) {
+            if (this.role_code === 'GA' || this.role_code === 'LIAISON') {
+              return true
+            }
+          }
+        }
+        return false
+      },
+      showModal: {
         get() {
           return this.showEditExamModal
         },
@@ -151,8 +365,178 @@
         }
       }
     },
+    methods: {
+      ...mapActions(['getBookings', 'getExams', 'getOffices', 'putBookingInfo', 'putExamInfo',]),
+      ...mapMutations(['setEditExamFailure', 'setEditExamSuccess', 'setSelectedExam', 'toggleEditExamModal',]),
+      allowSubmit() {
+        if (this.examRow) {
+          let fieldsEdited = false
+          let fields = Object.keys(this.fields)
+          for (let key of fields) {
+            if (this.fields[key] != this.examRow[key]) {
+              fieldsEdited = true
+              this.showMessage = false
+              break
+            }
+          }
+          return fieldsEdited
+        }
+        return false
+      },
+      getFilteredOffices(offices) {
+        if (offices.length === 0) {
+          this.officeChoices = [{office_id: null, office_name: 'No offices found with those letters'}]
+          return
+        }
+        this.officeChoices = offices.length >= 4 ? offices.slice(0,4) : offices
+      },
+      handleExamDropClick(e) {
+        this.fields.exam_type_id = e.target.id
+      },
+      handleExamInputClick() {
+        if (!this.clickedMenu) {
+          this.clickedMenu = true
+          return
+        }
+        this.clickedMenu = false
+      },
+      handleOfficeDropClick(e) {
+        this.showSearch = false
+        this.fields.office_id = e.target.id
+        this.search = e.target.name
+        this.office_number = e.target.value
+        this.searching = false
+      },
+      handleOfficeInput(e) {
+
+        this.searching = true
+        this.search = e.target.value
+        if (this.search.length > 1 && this.searching === true) {
+          this.showSearch = true
+        }
+        if (this.search.length <= 1) {
+          this.showSearch = false
+        }
+      },
+      handleOfficeNumberInput(e) {
+        let { value } = e.target
+        if (value.length <= 2) {
+          this.office_number = value
+        } else {
+          this.office_number = value.slice(value.length-2, value.length)
+        }
+        if (this.offices.find(office=>office.office_number == this.office_number)) {
+          let office = this.offices.find(office=>office.office_number == this.office_number)
+          this.search = office.office_name
+          this.fields.office_id = office.office_id
+        } else {
+          this.search = 'Invalid office number entered.'
+          this.fields.office_id = null
+        }
+      },
+      officeSearchOnBlur() {
+        this.searching = false
+      },
+      officeSearchOnFocus() {
+        this.searching = true
+        this.search = ''
+      },
+      populateForm() {
+        let exam = this.examRow
+        Object.keys(this.examRow).forEach( key => {
+          if (typeof exam[key] === 'string' || typeof exam[key] === 'number') {
+            Vue.set(
+              this.fields,
+              key,
+              exam[key]
+            )
+          }
+          if ( key === 'exam_received_date' ) {
+            this.fields[key] = this.exam[key]
+          }
+        })
+        if (this.fields.exam_received_date) {
+          this.exam_received = true
+        }
+        if (this.role_code === 'LIAISON') {
+          let office = this.offices.find(office => office.office_id == this.exam.office_id)
+          this.search = office.office_name
+          this.office_number = office.office_number
+        }
+      },
+      reset() {
+        Object.keys(this.fields).forEach(key => {
+          Vue.set(
+            this.fields,
+            key,
+            null
+          )
+        })
+        this.clickedMenu = false
+        this.message = null
+        this.office_number = null
+        this.exam_received = false
+        this.search = ''
+        this.searching = false
+        this.showMessage = false
+        this.showSearch = false
+        this.resetExam()
+      },
+      setMessage() {
+        if (!this.allowSubmit()) {
+          if (!this.fields.office_id) {
+            this.message = 'Please specify a valid office.'
+          } else {
+            this.message = 'Nothing has changed.  All fields contain their original values.'
+          }
+          this.showMessage = true
+        }
+      },
+      submit() {
+        let putRequest = {
+          exam_id: this.fields.exam_id
+        }
+        Object.keys(this.fields).forEach( key => {
+          if (this.fields[key] != this.examRow[key]) {
+            putRequest[key] = this.fields[key]
+          }
+        })
+        if (!this.exam_received && this.examRow.exam_received_date) {
+          putRequest['exam_received_date'] = null
+        }
+        this.putExamInfo(putRequest).then( () => {
+          this.getExams()
+          this.setEditExamSuccess(true)
+          this.toggleEditExamModal(false)
+        })
+      },
+      updateExamReceived(e) {
+        let { exam_received_date } = this.fields
+        if (e && !exam_received_date) {
+          this.fields['exam_received_date'] = new moment().utc().format('YYYY-MM-DD[T]hh:mm:ssZ')
+          return
+        }
+        if (!e && exam_received_date) {
+          this.fields['exam_received_date'] = null
+        }
+      }
+    },
   }
 </script>
 
 <style scoped>
+  .less-10-mb {
+    margin-bottom: -10px !important;
+  }
+  .less-15-mb {
+    margin-bottom: -15px !important;
+  }
+  .id-grid-1st-col {
+    margin-left: auto;
+    margin-right: 20px;
+  }
+  .id-grid-1st-col {
+    grid-column: 1 / span 2;
+    margin-right: 20px;
+  }
 </style>

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -17,19 +17,19 @@
                 <div class="id-grid-1st-col w-100 pr-2">
                   <div style="display: flex; justify-content: space-between; width: 100%">
                     <div>Exam:</div>
-                    <div>{{ this.exam.exam_name }}</div>
+                    <div>{{ examRow.exam_name }}</div>
                   </div>
                 </div>
                 <div class="pl-2">Event ID: </div>
-                <div class="q-id-grid-2nd-col">{{ this.exam.event_id }}</div>
+                <div class="q-id-grid-2nd-col">{{ examRow.event_id }}</div>
                 <div class="id-grid-1st-col w-100 pr-2">
                   <div style="display: flex; justify-content: space-between; width: 100%">
                     <div>Type:</div>
-                    <div>{{ this.exam.exam_type.exam_type_name }}</div>
+                    <div>{{ examRow.exam_type.exam_type_name }}</div>
                   </div>
                 </div>
                 <div class="pl-2">Writers: </div>
-                <div style="margin-left: auto;">{{ this.exam.number_of_students }}</div>
+                <div style="margin-left: auto;">{{ examRow.number_of_students }}</div>
               </div>
             </div>
           </b-col>
@@ -48,13 +48,13 @@
           <b-col cols="6" v-if="role_code !== 'GA' && role_code !== 'LIAISON'">
             <b-form-group>
               <label>Exam Time</label><br>
-              <b-input disabled :value="formatTime(this.exam.booking.start_time)" />
+              <b-input disabled :value="formatTime(examRow.booking.start_time)" />
             </b-form-group>
           </b-col>
           <b-col cols="6" v-if="role_code !== 'GA' && role_code !== 'LIAISON'">
             <b-form-group>
               <label>Exam Date</label><br>
-              <b-input disabled :value="formatDate(this.exam.booking.start_time)" />
+              <b-input disabled :value="formatDate(examRow.booking.start_time)" />
             </b-form-group>
           </b-col>
           <b-col cols="6" v-if="role_code === 'LIAISON' || role_code === 'GA'">
@@ -140,7 +140,7 @@
   export default {
     name: "EditGroupExamBookingModal",
     components: { DatePicker },
-    props: ['exam', 'resetExam'],
+    props: ['examRow', 'resetExam'],
     data () {
       return {
         invigilator_id: '',
@@ -301,7 +301,7 @@
         })
       },
       setValues() {
-        let tempItem = Object.assign({}, this.exam)
+        let tempItem = Object.assign({}, this.examRow)
         this.time = tempItem.booking.start_time
         this.date = tempItem.booking.start_time
         this.offsite_location = tempItem.offsite_location

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -60,7 +60,7 @@
         {{ row.item.offsite_location ? 'Group Exam' : row.item.examinee_name }}
       </template>
       <template slot="exam_received" slot-scope="row">
-        {{ row.item.exam_received === 0 ? 'No' : 'Yes' }}
+        {{ row.item.exam_received_date ? 'Yes' : 'No' }}
       </template>
       <template slot="expiry_date" slot-scope="row">
         {{ row.item.examinee_name === 'group exam' ? '–' : row.item.expiry_date.split('T')[0] }}
@@ -102,9 +102,9 @@
                                style="padding: -2px; margin: -2px; font-size: 1rem; color: dimgray"/>
           </template>
           <b-dropdown-item size="sm"
-                           @click.stop="editExam(row.item)">Edit Exam</b-dropdown-item>
+                           @click="editExam(row.item)">Edit Exam</b-dropdown-item>
           <b-dropdown-item size="sm"
-                           @click.stop="returnExamInfo(row.item)">Return Exam</b-dropdown-item>
+                           @click="returnExamInfo(row.item)">Return Exam</b-dropdown-item>
           <template v-if="row.item.booking && row.item.booking.invigilator_id">
             <b-dropdown-item v-if="row.item.offsite_location"
                              size="sm"
@@ -123,9 +123,9 @@
       </template>
     </b-table>
     </div>
-    <EditExamModal :exam="item" :resetExam="resetEditedExam" />
+    <EditExamModal :examRow="examRow" :resetExam="resetEditedExam" />
     <ReturnExamModal v-if="showReturnExamModalVisible" />
-    <EditGroupExamBookingModal :exam="item" :resetExam="resetEditedExam" />
+    <EditGroupExamBookingModal :examRow="examRow" :resetExam="resetEditedExam" />
   </div>
 </template>
 
@@ -137,6 +137,7 @@
   import SuccessExamAlert from './success-exam-alert'
   import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
   import moment from 'moment'
+  import Vue from 'vue'
 
   export default {
     name: "ExamInventoryTable",
@@ -152,7 +153,7 @@
     },
     data() {
       return {
-        item: null,
+        examRow: {},
         tableStyle: null,
         expiryFilter: 'current',
         scheduledFilter: 'unscheduled',
@@ -231,8 +232,41 @@
         'toggleReturnExamModalVisible',
         'setReturnExamInfo',
       ]),
-      handleExpiryFilter(e) {
-        this.expiryFilter = e.target.value
+      addBookingRoute(item) {
+        let bookingRoute = '/booking/scheduling'
+        this.$router.push(bookingRoute)
+        this.navigationVisible(false)
+        this.setSelectedExam(item)
+        this.toggleCalendarControls(false)
+        this.toggleExamInventoryModal(false)
+        this.toggleScheduling(true)
+        this.toggleSchedulingIndicator(true)
+      },
+      clickRow(e) {
+        if (this.showExamInventoryModal) {
+          this.$root.$emit('toggleOffsite', false)
+          this.$root.$emit('options', {name: 'selectable', value: true})
+          this.navigationVisible(false)
+          this.setSelectedExam(e)
+          this.toggleCalendarControls(false)
+          this.toggleExamInventoryModal(false)
+          this.toggleScheduling(true)
+          this.toggleSchedulingIndicator(true)
+        }
+      },
+      editExam(item) {
+        Object.keys(item).forEach( i => {
+          Vue.set(
+            this.examRow,
+            i,
+            item[i]
+          )
+        })
+        this.toggleEditExamModal(true)
+      },
+      editGroupExam(item) {
+        this.examRow = item
+        this.toggleEditGroupBookingModal(true)
       },
       filteredExams() {
         let exams = this.exam_inventory || []
@@ -252,7 +286,9 @@
               filtered = exams.filter(ex => moment(ex.expiry_date).isBefore(moment(), 'day'))
               break
             case 'current':
-              filtered = exams.filter(ex => moment(ex.expiry_date).isSameOrAfter(moment(), 'day'))
+              let step1 = exams.filter(ex => moment(ex.expiry_date).isSameOrAfter(moment(), 'day'))
+              let step2 = exams.filter(ex => !ex.expiry_date)
+              filtered = step1.concat(step2)
               break
             default:
               filtered = exams
@@ -292,9 +328,21 @@
         }
         return []
       },
-      handleFilter(e) {
-        this[e.type] = e.value
-        localStorage.setItem(e.type, e.value)
+      formatDate(d) {
+        return new moment(d).format('MMM DD, YYYY')
+      },
+      formatTime(d) {
+        return new moment(d).format('h:mm a')
+      },
+      getInvigilator(row) {
+        if (this.events) {
+          let bookingObj = this.events.find(event=>event.booking_id==row.item.booking_id)
+          if (bookingObj && bookingObj.invigilator) {
+            return bookingObj.invigilator.invigilator_name
+          }
+          return ''
+        }
+        return ''
       },
       getWidth() {
         if (!this.showExamInventoryModal) {
@@ -307,45 +355,24 @@
       handleBookedFilter(e) {
         this.bookedFilter = e.target.value
       },
+      handleExpiryFilter(e) {
+        this.expiryFilter = e.target.value
+      },
+      handleFilter(e) {
+        this[e.type] = e.value
+        localStorage.setItem(e.type, e.value)
+      },
       resetButtons() {
         this.buttons.all = 'btn-secondary'
         this.buttons.current = 'btn-secondary'
         this.buttons.expired = 'btn-secondary'
       },
-      getInvigilator(row) {
-        if (this.events) {
-          let bookingObj = this.events.find(event=>event.booking_id==row.item.booking_id)
-          if (bookingObj && bookingObj.invigilator) {
-            return bookingObj.invigilator.invigilator_name
-          }
-          return ''
-        }
-        return ''
-      },
-      clickRow(e) {
-        if (this.showExamInventoryModal) {
-          this.$root.$emit('toggleOffsite', false)
-          this.$root.$emit('options', {name: 'selectable', value: true})
-          this.navigationVisible(false)
-          this.setSelectedExam(e)
-          this.toggleCalendarControls(false)
-          this.toggleExamInventoryModal(false)
-          this.toggleScheduling(true)
-          this.toggleSchedulingIndicator(true)
-        }
-      },
-      editExam(item) {
-        this.item = item
-        this.setEditExamInfo(item)
-        this.toggleEditExamModal(true)
+      resetEditedExam() {
+        this.examRow = {}
       },
       returnExamInfo(item) {
         this.toggleReturnExamModalVisible(true)
         this.setReturnExamInfo(item)
-      },
-      editGroupExam(item) {
-        this.item = item
-        this.toggleEditGroupBookingModal(true)
       },
       updateBookingRoute(item) {
         let calendarEvent = this.calendarEvents.find(event => event.id == item.booking_id)
@@ -353,25 +380,6 @@
         this.setEditedBooking(calendarEvent)
         this.toggleEditBookingModal(true)
         this.$router.push('/booking/' + moment(item.booking.start_time).format('YYYY-MM-DD'))
-      },
-      resetEditedExam() {
-        this.item = {}
-      },
-      formatDate(d) {
-        return new moment(d).format('MMM DD, YYYY')
-      },
-      formatTime(d) {
-        return new moment(d).format('h:mm a')
-      },
-      addBookingRoute(item) {
-        let bookingRoute = '/booking/?schedule=1'
-        this.$router.push(bookingRoute)
-        this.navigationVisible(false)
-        this.setSelectedExam(item)
-        this.toggleCalendarControls(false)
-        this.toggleExamInventoryModal(false)
-        this.toggleScheduling(true)
-        this.toggleSchedulingIndicator(true)
       },
     },
   }

--- a/frontend/src/exams/exams.vue
+++ b/frontend/src/exams/exams.vue
@@ -21,6 +21,10 @@
 
   export default {
     name: "Exams",
+    components: { ExamInventoryTable },
+    mounted() {
+      this.$store.dispatch('getOffices')
+    },
     computed: {
       ...mapState([
         'user',
@@ -29,7 +33,6 @@
         'showExams',
       ])
     },
-    components: { ExamInventoryTable },
   }
 </script>
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1586,8 +1586,10 @@ export const store = new Vuex.Store({
     },
 
     putExamInfo(context, payload) {
+      let id = payload.exam_id.valueOf()
+      delete payload.exam_id
       return new Promise((resolve, reject) => {
-        let url = `/exams/${context.state.selectedExam.exam_id}/`
+        let url = `/exams/${id}/`
         Axios(context).put(url, payload).then( resp =>{
           resolve(resp)
           context.commit('setEditExamSuccess', true)
@@ -1661,12 +1663,11 @@ export const store = new Vuex.Store({
       }
       
       let defaultValues = {
-        exam_received: 0,
         exam_returned_ind: 0,
         examinee_name: 'group exam',
-        expiry_date: new moment('2499-01-01T12:00:00-08:00').toString()
       }
       delete responses.exam_time
+      delete responses.expiry_date
       if (responses.notes === null) {
         data.notes = ''
       }
@@ -1695,7 +1696,6 @@ export const store = new Vuex.Store({
     postITAIndividualExam(context) {
       let responses = Object.assign( {}, context.state.capturedExam)
       let defaultValues = {
-        exam_received: 1,
         exam_returned_ind: 0,
         number_of_students: 1,
         office_id: context.state.user.office_id


### PR DESCRIPTION
Created a new edit exam form that has multiple setups with different fields for the various types of CSRs that allows editing of all the required fields.  Built a new office search functionality that allows for typing directly into the input field with suggestions populating beneath or inputing the office number.
Also fixed previously undocumented bug which caused a exam_received_date to be set to the current date during the initial capture of a group exam--value now remains unset for branch staff to update when appropriate.