### PR TITLE
Generate CSV Date Picker

### DIFF
--- a/frontend/src/exams/generate-financial-report-modal.vue
+++ b/frontend/src/exams/generate-financial-report-modal.vue
@@ -17,16 +17,19 @@
       <b-row class="my-1">
         <b-col sm="4"><label>Start Date:</label></b-col>
         <b-col sm="6">
-          <b-form-input id="startDate"
-                        type="date"
-                        v-model=startDate />
+          <DatePicker v-model="startDate"
+                      input-class="form-control"
+                      class="w-100 less-10-mb"
+                      lang="en"/>
         </b-col>
       </b-row>
       <b-row class="my-1">
         <b-col sm="4"><label>End Date:</label></b-col>
-        <b-col sm="6"><b-form-input id="endDate"
-                                    type="date"
-                                    v-model=endDate />
+        <b-col sm="6">
+          <DatePicker v-model="endDate"
+                      input-class="form-control"
+                      class="w-100 less-10-mb"
+                      lang="en"/>
         </b-col>
       </b-row>
       <b-row>
@@ -45,11 +48,12 @@
 
 <script>
     import { mapState, mapMutations, mapActions } from 'vuex'
-    import OfficeDropDownFilter from './office-dropdown-filter'
+    import DatePicker from 'vue2-datepicker'
     import moment from 'moment'
     const FileDownload = require('js-file-download')
     export default {
         name: "FinancialReportModal",
+        components: { DatePicker },
         data() {
           return {
             startDate: '',
@@ -71,8 +75,8 @@
             'toggleGenFinReport',
           ]),
           submit() {
-            let form_start_date = this.startDate
-            let form_end_date = this.endDate
+            let form_start_date = moment.utc(this.startDate).format('YYYY-MM-DD')
+            let form_end_date = moment.utc(this.endDate).format('YYYY-MM-DD')
             let exam_type = this.selectedExamType
             let url = '/exams/export/?start_date=' + form_start_date + '&end_date=' + form_end_date + '&exam_type='
                       + exam_type


### PR DESCRIPTION
After testing, it was determined that the generate CSV modal's datepicker was not using the same datepicker that the rest of Bookings was using. This was changed by importing the DatePicker component from the vu2-datepicker library and replacing the old date picker with the new one.