### PR TITLE
Fixed issues when clicking 'reschedule' and 'schedule' from exam inventory

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,7 +33,7 @@ limitations under the License.*/
 </template>
 
 <script>
-  import { mapState, mapGetters, mapMutations, mapActions } from 'vuex'
+  import { mapState, mapGetters } from 'vuex'
   import Alert from './alert'
   import ExamAlert from './exam-alert'
   import FailureExamAlert from './exams/failure-exam-alert'
@@ -64,13 +64,14 @@ limitations under the License.*/
       SuccessExamAlert,
     },
     computed: {
-      ...mapState(['isLoggedIn', 'showSchedulingIndicator', 'user' ]),
+      ...mapGetters(['show_scheduling_indicator']),
+      ...mapState(['isLoggedIn', 'user' ]),
       style() {
-        let output = {marginTop: 72+'px', width: '100%', overflowY: 'auto'}
-        if (this.showSchedulingIndicator) {
+        let output = {marginTop: 72+'px', width: '100%',}
+        if (this.show_scheduling_indicator) {
           output['marginBottom'] = 100+'px'
         }
-        if (!this.showSchedulingIndicator) {
+        if (!this.show_scheduling_indicator) {
           output['marginBottom'] = 40+'px'
         }
         return output

--- a/frontend/src/assets/css/q.css
+++ b/frontend/src/assets/css/q.css
@@ -45,26 +45,38 @@
    border: 1px solid lightgrey;
    height: 100%;
    width: 100%;
-   padding: 7px;
+   padding: 4px;
  }
 .q-id-grid-outer {
   display: grid;
-  grid-template-columns: 2fr 3fr 2fr 3fr;
+  grid-template-columns: 1fr 1fr;
 }
-.q-id-grid-1st-col {
-  margin-left: auto;
-  margin-right: 20px;
+.q-id-grid-1-col {
+  margin-left: 4px;
+  margin-right: 4px;
+  display: flex;
+  justify-content: space-between;
+  grid-column: 1 / span 1;
 }
-.q-id-grid-2nd-col {
-  margin-left: auto;
+
+.q-id-grid-2-col {
+  margin-left: 4px;
+  margin-right: 4px;
+  display: flex;
+  justify-content: space-between;
+  grid-column: 2 / span 1;
 }
-.q-id-grid-2nd-head {
-  margin-left: 10px;
+.q-id-grid-title {
+  font-weight: normal;
 }
-.q-id-grid-top-head {
-  grid-column-start: 1;
-  grid-column-end: 5;
+.q-id-grid-item {
+  font-weight: lighter;
+}
+.q-id-grid-head {
   margin-right: auto;
-  font-weight: 600;
-  padding-bottom: 5px;
+  margin-left: 5px;
+  grid-column: 1 / span 2;
+}
+.q-custom-tr {
+  max-height: 35px !important;
 }

--- a/frontend/src/booking/booking-modal.vue
+++ b/frontend/src/booking/booking-modal.vue
@@ -96,21 +96,18 @@
       ...mapActions(['scheduleExam', 'getInvigilators']),
       ...mapMutations([
         'toggleBookingModal',
-        'toggleSchedulingIndicator',
         'setClickedDate',
       ]),
       cancel() {
-        this.$root.$emit('toggleOffsite', true)
         this.toggleBookingModal(false)
-        this.toggleSchedulingIndicator(true)
         this.setClickedDate(null)
+        this.$root.$emit('removeSavedSelection')
       },
       show() {
         this.selectedInvigilator = null
       },
       postEvent(e) {
         e.preventDefault()
-        this.$root.$emit('toggleOffsite', true)
         let start = new moment(this.date.start).utc()
         let end = new moment(this.endTime).utc()
         let booking = {
@@ -121,9 +118,9 @@
           booking_name: this.exam.exam_name,
           invigilator_id: this.selectedInvigilator
         }
-        this.scheduleExam(booking)
-        this.$root.$emit('unselect')
-        this.$root.$emit('options', {name: 'selectable', value: false})
+        this.scheduleExam(booking).then(()=>{
+          this.toggleBookingModal(false)
+        })
       }
     },
     mounted(){

--- a/frontend/src/booking/buttons-calendar.vue
+++ b/frontend/src/booking/buttons-calendar.vue
@@ -14,7 +14,7 @@
       <b-button class="btn-primary mx-2" @click="today">Today</b-button>
       <DropdownCalendar class="mr-3" />
       <b-dropdown variant="primary"
-                  v-if="showCalendarControls"
+                  v-if="!scheduling && !rescheduling"
                   class="mr-3 ml-3"
                   text="Schedule an Event...">
         <b-dropdown-item @click="showExamModal">
@@ -36,27 +36,16 @@
     name: 'ButtonsCalendar',
     components: { DropdownCalendar },
     computed: {
-      ...mapState(['showCalendarControls',])
+      ...mapState(['scheduling', 'rescheduling'])
     },
     methods: {
-      ...mapMutations([
-        'toggleExamInventoryModal',
-        'toggleScheduling',
-        'toggleCalendarControls',
-        'toggleSchedulingIndicator',
-        'toggleSchedulingOther',
-        'navigationVisible'
-      ]),
+      ...mapMutations(['setSelectedExam', 'toggleExamInventoryModal', 'toggleScheduling',]),
       showExamModal() {
         this.toggleExamInventoryModal(true)
       },
       scheduleOtherEvent() {
-        this.$root.$emit('toggleOffsite', false)
-        this.navigationVisible(false)
-        this.toggleCalendarControls(false)
-        this.toggleSchedulingOther(true)
-        this.toggleSchedulingIndicator(true)
-        this.$root.$emit('options', {name: 'selectable', value: true})
+        this.setSelectedExam(null)
+        this.toggleScheduling(true)
       },
       next() {
         this.$root.$emit('next')

--- a/frontend/src/booking/exam-inventory-modal.vue
+++ b/frontend/src/booking/exam-inventory-modal.vue
@@ -24,14 +24,10 @@
     methods: {
       ...mapMutations([
         'toggleExamInventoryModal',
-        'navigationVisible',
         'toggleScheduling',
-        'toggleSchedulingIndicator'
       ]),
       cancel() {
-        this.toggleSchedulingIndicator(false)
         this.toggleExamInventoryModal(false)
-        this.navigationVisible(true)
         this.toggleScheduling(false)
       }
     }

--- a/frontend/src/booking/other-booking-modal.vue
+++ b/frontend/src/booking/other-booking-modal.vue
@@ -11,17 +11,18 @@
            size="md">
     <div v-if="showModal" style="margin: 10px">
       <div v-if="minimized || !confirm" style="display: flex; justify-content: space-between">
-        <div><h5>Edit Booking</h5></div>
+        <div><h5>Other Booking</h5></div>
         <div><button class="btn btn-link"
                   @click="minimized = !minimized">{{ minimized ? "Maximize" : "Minimize" }}</button></div>
       </div>
+      <div class="mb-1" style="font-size:1rem;">{{ startTime.format('ddd MMMM Do, YYYY') }}</div>
         <template v-if="!minimized">
           <b-form>
             <b-form-group>
               <label>Event Title<span style="color: red">{{ message }}</span></label><br>
               <b-input :state="state" type="text" v-model="title" />
             </b-form-group>
-            <b-row>
+            <b-form-row>
               <b-col cols="5">
                 <b-form-group>
                   <label>Collect Fees</label><br>
@@ -34,7 +35,7 @@
                   <b-input readonly :value="resource.title" />
                 </b-form-group>
               </b-col>
-            </b-row>
+            </b-form-row>
             <b-form-row v-if="fees">
               <b-col cols="4">
                 <b-form-group>
@@ -58,7 +59,7 @@
               </b-col>
             </b-form-row>
             <b-form-row>
-              <b-col cols="4">
+              <b-col>
                 <b-form-group>
                   <label>Start Time</label><br>
                   <b-input type="text"
@@ -66,7 +67,7 @@
                            :value="startTime.format('hh:mm a')" />
                 </b-form-group>
               </b-col>
-              <b-col cols="4">
+              <b-col>
                 <b-form-group>
                   <label>End Time</label><br>
                   <b-input type="text"
@@ -74,7 +75,7 @@
                            :value="endTime.format('hh:mm a')" />
                 </b-form-group>
               </b-col>
-              <b-col cols="4">
+              <b-col cols="5">
                 <b-form-group>
                   <label>Duration</label><br>
                   <b-button-group>
@@ -86,7 +87,7 @@
                     <b-input :value="displayDuration"
                              readonly
                              style="border-radius: 0px"
-                             class="w-50"/>
+                             class="w-100"/>
                     <b-button @click="incrementDuration" >
                       <font-awesome-icon icon="plus"
                                          class="m-0 p-0"
@@ -194,22 +195,12 @@
       ...mapActions(['postBooking', 'finishBooking']),
       ...mapMutations([
         'toggleOtherBookingModal',
-        'toggleSchedulingIndicator',
-        'toggleSchedulingOther',
-        'navigationVisible',
-        'toggleCalendarControls',
       ]),
       cancel() {
-        this.$root.$emit('toggleOffsite', false)
-        this.toggleSchedulingOther(true)
-        this.toggleSchedulingIndicator(true)
-        this.toggleOtherBookingModal(false)
-        this.$root.$emit('unselect')
         this.$root.$emit('removeSavedSelection')
         this.message = ''
       },
       show() {
-        this.toggleSchedulingIndicator(false)
         this.message = ''
         this.added = 0
         this.title = ''
@@ -237,7 +228,6 @@
       },
       postEvent(e) {
         e.preventDefault()
-        this.$root.$emit('toggleOffsite', true)
         if (this.title.length > 0) {
           this.message = ''
           this.state = null
@@ -252,7 +242,6 @@
           }
           this.postBooking(booking).then( () => {
             this.finishBooking()
-            this.$root.$emit('options', {name: 'selectable', value: false})
           })
         } else {
           this.message = ' (Required)'

--- a/frontend/src/exams/add-exam-form-modal.vue
+++ b/frontend/src/exams/add-exam-form-modal.vue
@@ -241,6 +241,7 @@
         }
         this.unSubmitted = true
         this.submitMsg = ''
+        this.status = 'unknown'
       },
       tryAgain() {
         this.unSubmitted = true
@@ -271,10 +272,7 @@
       resetModal() {
         this.resetCaptureForm()
         this.resetCaptureTab()
-        this.unSubmitted = true
-        this.submitMsg = ''
-        this.status = 'unknown'
-
+        this.initialize()
       },
       setWarning() {
         if (!this.errors.includes(this.step)) {

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -366,7 +366,7 @@
       }
     },
     methods: {
-      ...mapActions(['getBookings', 'getExams', 'getOffices', 'putBookingInfo', 'putExamInfo',]),
+      ...mapActions(['getBookings', 'getExams', 'getOffices', 'putExamInfo',]),
       ...mapMutations(['setEditExamFailure', 'setEditExamSuccess', 'setSelectedExam', 'toggleEditExamModal',]),
       allowSubmit() {
         if (this.examRow) {

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -11,35 +11,35 @@
         </b-input-group-prepend>
         <b-btn-group horizontal class="pt-2">
           <b-btn size="sm"
-                 :pressed="expiryFilter==='all'"
+                 :pressed="inventoryFilters.expiryFilter==='all'"
                  @click="handleFilter({type:'expiryFilter', value:'all'})"><span class="mx-2">All</span></b-btn>
           <b-btn size="sm"
-                 :pressed="expiryFilter==='expired'"
+                 :pressed="inventoryFilters.expiryFilter==='expired'"
                  @click="handleFilter({type:'expiryFilter', value:'expired'})">Expired</b-btn>
           <b-btn size="sm"
-                 :pressed="expiryFilter==='current'"
+                 :pressed="inventoryFilters.expiryFilter==='current'"
                  @click="handleFilter({type:'expiryFilter', value:'current'})">Current</b-btn>
         </b-btn-group>
         <b-btn-group horizontal class="ml-2 pt-2">
           <b-btn size="sm"
-                 :pressed="scheduledFilter==='both'"
+                 :pressed="inventoryFilters.scheduledFilter==='both'"
                  @click="handleFilter({type:'scheduledFilter', value:'both'})"><span class="mx-2">Both</span></b-btn>
           <b-btn size="sm"
-                 :pressed="scheduledFilter==='unscheduled'"
+                 :pressed="inventoryFilters.scheduledFilter==='unscheduled'"
                  @click="handleFilter({type:'scheduledFilter', value:'unscheduled'})">Un-Scheduled</b-btn>
           <b-btn size="sm"
-                 :pressed="scheduledFilter==='scheduled'"
+                 :pressed="inventoryFilters.scheduledFilter==='scheduled'"
                  @click="handleFilter({type:'scheduledFilter', value:'scheduled'})">Scheduled</b-btn>
         </b-btn-group>
         <b-btn-group horizontal class="ml-2 pt-2">
           <b-btn size="sm"
-                 :pressed="groupFilter==='both'"
+                 :pressed="inventoryFilters.groupFilter==='both'"
                  @click="handleFilter({type:'groupFilter', value:'both'})"><span class="mx-2">Both</span></b-btn>
           <b-btn size="sm"
-                 :pressed="groupFilter==='individual'"
+                 :pressed="inventoryFilters.groupFilter==='individual'"
                  @click="handleFilter({type:'groupFilter', value:'individual'})">Individual</b-btn>
           <b-btn size="sm"
-                 :pressed="groupFilter==='group'"
+                 :pressed="inventoryFilters.groupFilter==='group'"
                  @click="handleFilter({type:'groupFilter', value:'group'})">Group</b-btn>
         </b-btn-group>
       </b-input-group>`
@@ -51,6 +51,7 @@
                style="border: 1px solid dimgrey"
                empty-text="There are no exams that match this filter criteria"
                small
+               tbody-tr-class="q-custom-tr"
                outlined
                @row-clicked="clickRow"
                hover
@@ -63,7 +64,7 @@
         {{ row.item.exam_received_date ? 'Yes' : 'No' }}
       </template>
       <template slot="expiry_date" slot-scope="row">
-        {{ row.item.examinee_name === 'group exam' ? '–' : row.item.expiry_date.split('T')[0] }}
+        {{ row.item.examinee_name === 'group exam' ? '–' : formatDate(row.item.expiry_date) }}
       </template>
       <template slot="scheduled" slot-scope="row">
         <b-button v-if="row.item.booking_id && row.item.booking.invigilator_id"
@@ -155,9 +156,6 @@
       return {
         examRow: {},
         tableStyle: null,
-        expiryFilter: 'current',
-        scheduledFilter: 'unscheduled',
-        groupFilter: 'both',
         filter: null,
         events: null,
         bookingRouteString: '',
@@ -170,6 +168,7 @@
         'calendarSetup',
         'calendarEvents',
         'exams',
+        'inventoryFilters',
         'showEditExamModal',
         'showExamInventoryModal',
         'showReturnExamModalVisible',
@@ -217,41 +216,32 @@
     methods: {
       ...mapActions(['getExams', 'getBookings', 'getInvigilators']),
       ...mapMutations([
-        'navigationVisible',
-        'setSelectedExam',
-        'toggleCalendarControls',
-        'toggleExamInventoryModal',
-        'toggleScheduling',
-        'toggleSchedulingIndicator',
-        'toggleEditBookingModal',
-        'toggleEditExamModal',
-        'toggleEditGroupBookingModal',
         'setEditedBooking',
         'setEditedBookingOriginal',
         'setEditExamInfo',
-        'toggleReturnExamModalVisible',
+        'setInventoryFilters',
         'setReturnExamInfo',
+        'setSelectedExam',
+        'toggleEditBookingModal',
+        'toggleEditExamModal',
+        'toggleEditGroupBookingModal',
+        'toggleExamInventoryModal',
+        'toggleReturnExamModalVisible',
+        'toggleScheduling',
       ]),
       addBookingRoute(item) {
-        let bookingRoute = '/booking/scheduling'
-        this.$router.push(bookingRoute)
-        this.navigationVisible(false)
-        this.setSelectedExam(item)
-        this.toggleCalendarControls(false)
-        this.toggleExamInventoryModal(false)
         this.toggleScheduling(true)
-        this.toggleSchedulingIndicator(true)
+        item.referringAction = 'scheduling'
+        this.setSelectedExam(item)
+        this.$router.push('/booking')
+        this.toggleExamInventoryModal(false)
       },
-      clickRow(e) {
+      clickRow(item) {
         if (this.showExamInventoryModal) {
-          this.$root.$emit('toggleOffsite', false)
-          this.$root.$emit('options', {name: 'selectable', value: true})
-          this.navigationVisible(false)
-          this.setSelectedExam(e)
-          this.toggleCalendarControls(false)
-          this.toggleExamInventoryModal(false)
           this.toggleScheduling(true)
-          this.toggleSchedulingIndicator(true)
+          this.setSelectedExam(item)
+          this.$router.push('/booking')
+          this.toggleExamInventoryModal(false)
         }
       },
       editExam(item) {
@@ -278,7 +268,7 @@
             let evenMoreFiltered = moreFiltered.filter(ex => !ex.offsite_location)
             return evenMoreFiltered
           }
-          switch (this.expiryFilter) {
+          switch (this.inventoryFilters.expiryFilter) {
             case 'all':
               filtered = exams
               break
@@ -295,7 +285,7 @@
               break
           }
           let moreFiltered = []
-          switch (this.scheduledFilter) {
+          switch (this.inventoryFilters.scheduledFilter) {
             case 'both':
               moreFiltered = filtered
               break
@@ -310,7 +300,7 @@
               break
           }
           let evenMoreFiltered = []
-          switch (this.groupFilter) {
+          switch (this.inventoryFilters.groupFilter) {
             case 'both':
               evenMoreFiltered = moreFiltered
               break
@@ -352,15 +342,8 @@
           this.tableStyle = { width: 98 + '%' }
         }
       },
-      handleBookedFilter(e) {
-        this.bookedFilter = e.target.value
-      },
-      handleExpiryFilter(e) {
-        this.expiryFilter = e.target.value
-      },
       handleFilter(e) {
-        this[e.type] = e.value
-        localStorage.setItem(e.type, e.value)
+        this.setInventoryFilters(e)
       },
       resetButtons() {
         this.buttons.all = 'btn-secondary'
@@ -375,11 +358,16 @@
         this.setReturnExamInfo(item)
       },
       updateBookingRoute(item) {
-        let calendarEvent = this.calendarEvents.find(event => event.id == item.booking_id)
-        this.setEditedBookingOriginal(calendarEvent)
-        this.setEditedBooking(calendarEvent)
+        item.gotoDate = new moment(item.booking.start_time)
+        item.referringAction = 'rescheduling'
+        this.setSelectedExam(item)
+        let booking = this.calendarEvents.find(event => event.id == item.booking_id)
+        booking.start = new moment(booking.start)
+        booking.end = new moment(booking.end)
+        this.setEditedBooking(booking)
+        this.setEditedBookingOriginal(booking)
         this.toggleEditBookingModal(true)
-        this.$router.push('/booking/' + moment(item.booking.start_time).format('YYYY-MM-DD'))
+        this.$router.push('/booking')
       },
     },
   }

--- a/frontend/src/layout/nav.vue
+++ b/frontend/src/layout/nav.vue
@@ -23,7 +23,7 @@
            style="flex-grow: 8"
            class="q-inline-title">{{ calendarSetup.title }}</div>
     <div />
-      <div v-if="navigationVisible">
+      <div v-if="!scheduling && !rescheduling">
         <b-dropdown variant="outline-primary"
                     class="pl-0 ml-0 mr-3"
                     right
@@ -68,19 +68,18 @@
 
 <script>
   import { mapState, mapActions, mapMutations, mapGetters } from 'vuex'
-  import SchedulingIndicator from '../booking/scheduling-indicator'
 
   export default {
     name: 'Nav',
-    components: { SchedulingIndicator },
     computed: {
       ...mapGetters(['showExams']),
       ...mapState([
-        'navigationVisible',
-        'showServiceModal',
-        'showGAScreenModal',
-        'user',
         'calendarSetup',
+        'rescheduling',
+        'scheduling',
+        'showGAScreenModal',
+        'showServiceModal',
+        'user',
       ]),
       isGAorCSR() {
         if (this.user && this.user.role) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -23,7 +23,6 @@ var flashInt
 Vue.use(Vuex)
 
 export const store = new Vuex.Store({
-  
   state: {
     addIndITASteps: [
       {
@@ -300,7 +299,11 @@ export const store = new Vuex.Store({
     iframeLogedIn: false,
     invigilators: [],
     isLoggedIn: false,
-    navigationVisible: true,
+    inventoryFilters: {
+      expiryFilter: 'current',
+      scheduledFilter: 'unscheduled',
+      groupFilter: 'both',
+    },
     nowServing: false,
     offices: [],
     officeFilter: null,
@@ -311,8 +314,6 @@ export const store = new Vuex.Store({
     rooms: [],
     roomResources: [],
     scheduling: false,
-    schedulingOther: false,
-    selectedBooking: {},
     selectedExam: {},
     selectedOffice: {},
     selectionIndicator: false,
@@ -333,7 +334,6 @@ export const store = new Vuex.Store({
     showAddModal: false,
     showAdmin: false,
     showBookingModal: false,
-    showCalendarControls: true,
     showEditBookingModal: false,
     showEditGroupBookingModal: false,
     showEditExamModal: false,
@@ -344,7 +344,6 @@ export const store = new Vuex.Store({
     showOtherBookingModal: false,
     showResponseModal: false,
     showReturnExamModalVisible: false,
-    showSchedulingIndicator: false,
     showServiceModal: false,
     user: {
       csr_id: null,
@@ -370,6 +369,15 @@ export const store = new Vuex.Store({
   },
 
   getters: {
+    show_scheduling_indicator: (state) => {
+      if (state.scheduling || state.rescheduling) {
+        if (!state.showOtherBookingModal && !state.showBookingModal && !state.showEditBookingModal) {
+          return true
+        }
+        return false
+      }
+      return false
+    },
     
     get_room_by_id: (state) => (id) => {
       return state.rooms.find(room => room.id == id)
@@ -424,16 +432,10 @@ export const store = new Vuex.Store({
           nextClass: 'btn-secondary disabled',
           nextDisabled: true
         }
-      } else if (setup.step < setup.highestStep) {
-        return {
-          nextClass: 'btn-primary',
-          nextDisabled: false
-        }
-      } else {
-        return {
-          nextClass: 'btn-primary',
-          nextDisabled: false
-        }
+      }
+      return {
+        nextClass: 'btn-primary',
+        nextDisabled: false
       }
     },
 
@@ -1602,19 +1604,6 @@ export const store = new Vuex.Store({
           })
       })
     },
-
-    putBookingInfo(context, payload) {
-      return new Promise((resolve, reject) => {
-        let url = `/bookings/${context.state.selectedBooking.booking_id}/`
-        Axios(context).put(url, payload).then( resp =>{
-          resolve(resp)
-        })
-          .catch(error => {
-            reject(error)
-          })
-      })
-    },
-
     
     postBooking(context, payload) {
       if (!Object.keys(payload).includes('office_id')) {
@@ -1633,11 +1622,7 @@ export const store = new Vuex.Store({
     finishBooking(context) {
       context.dispatch('getBookings')
       context.commit('setSelectionIndicator', false)
-      context.commit('navigationVisible', true)
-      context.commit('toggleCalendarControls', true)
       context.commit('toggleScheduling', false)
-      context.commit('toggleSchedulingOther', false)
-      context.commit('toggleSchedulingIndicator', false)
       context.commit('toggleBookingModal', false)
       context.commit('toggleOtherBookingModal', false)
       context.commit('setClickedDate', null)
@@ -2334,23 +2319,26 @@ export const store = new Vuex.Store({
 
     setExamMethods: (state, payload) => state.examMethods = payload,
 
-    setSelectedExam: (state, payload) => state.selectedExam = payload,
-
-    setSelectedBooking: (state, payload) => state.selectedBooking = payload,
+    setSelectedExam(state, payload) {
+      if (payload === 'clearGoto') {
+        delete state.selectedExam.gotoDate
+        return
+      }
+      state.selectedExam = payload
+    },
   
-    toggleScheduling: (state, payload) => state.scheduling = payload,
-    
-    toggleCalendarControls: (state, payload) => state.showCalendarControls = payload,
-  
-    navigationVisible: (state, payload) => state.navigationVisible = payload,
+    toggleScheduling: (state, payload) => {
+      if (!payload) {
+        state.scheduling = payload
+        state.rescheduling = payload
+        return
+      }
+      state.scheduling = payload
+    },
     
     setCalendarSetup: (state, payload) => state.calendarSetup = payload,
-  
-    toggleSchedulingOther: (state, payload) => state.schedulingOther = payload,
     
     toggleOtherBookingModal: (state, payload) => state.showOtherBookingModal = payload,
-  
-    toggleSchedulingIndicator: (state, payload) => state.showSchedulingIndicator= payload,
 
     setEditExamSuccess: (state, payload) => state.editExamSuccess = payload,
 
@@ -2359,12 +2347,12 @@ export const store = new Vuex.Store({
     toggleEditBookingModal: (state, payload) => state.showEditBookingModal = payload,
   
     setEditedBooking(state, payload) {
-      if (payload) {
-        let eventCopy = Object.assign({}, payload)
-        state.editedBooking = eventCopy
+      if (typeof payload === 'object' && payload !== null) {
+        state.editedBooking = Object.assign({}, payload)
       }
       if (!payload) {
         state.editedBooking = null
+        state.editedBookingOriginal = null
       }
     },
   
@@ -2399,5 +2387,9 @@ export const store = new Vuex.Store({
     },
   
     toggleEditGroupBookingModal: (state, payload) => state.showEditGroupBookingModal = payload,
+  
+    setInventoryFilters(state, payload) {
+      state.inventoryFilters[payload.type] = payload.value
+    },
   }
 })


### PR DESCRIPTION
Scheduling and rescheduling exams from the exam inventory view now work properly and display of the offsite room is now as expected.  Simplified the calendar component, removing numerous redundant state properties and mutations, as well as removed the use of the router for any of the calendar's functionality.  Removed several other unused state properties and related mutations, fixed a bug in the add individual ita exam workflow where if logging two exams in a row, for the second exam the "Exam Received Today" option was not preselected.  Also fixed the bug causing jitter when opening the hamburger menu in some circumstances.