### PR TITLE
Fixed issue with exam inventory modal filters

### DIFF
--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -12,24 +12,23 @@
           <b-col class="mb-2">
             <div class="q-info-display-grid-container">
               <div class="q-id-grid-outer">
-                <div class="id-grid-1st-col w-100 pr-2">
+                <div class="q-id-grid-head">Exam Details</div>
+                <div class="q-id-grid-col">
+                  <div>Exam: </div>
+                  <div>{{ examRow.exam_name }}</div>
                 </div>
-                <div class="id-grid-1st-col w-100 pr-2">
-                  <div style="display: flex; justify-content: space-between; width: 100%">
-                    <div>Exam:</div>
-                    <div>{{ examRow.exam_name }}</div>
-                  </div>
+                <div class="q-id-grid-col">
+                  <div>Event ID: </div>
+                  <div>{{ examRow.event_id }}</div>
                 </div>
-                <div class="pl-2">Event ID: </div>
-                <div class="q-id-grid-2nd-col">{{ examRow.event_id }}</div>
-                <div class="id-grid-1st-col w-100 pr-2">
-                  <div style="display: flex; justify-content: space-between; width: 100%">
-                    <div>Type:</div>
-                    <div>{{ examRow.exam_type.exam_type_name }}</div>
-                  </div>
+                <div class="q-id-grid-col">
+                  <div>Type: </div>
+                  <div>{{ examRow.exam_type.exam_type_name }}</div>
                 </div>
-                <div class="pl-2">Writers: </div>
-                <div style="margin-left: auto;">{{ examRow.number_of_students }}</div>
+                <div class="q-id-grid-col">
+                  <div>Writers: </div>
+                  <div>{{ examRow.number_of_students }}</div>
+                </div>
               </div>
             </div>
           </b-col>
@@ -160,9 +159,11 @@
       }),
       invigilatorOptions() {
         if (this.invigilators && this.invigilators.length > 0) {
-          return this.invigilators.map( inv =>
+          let options = this.invigilators.map( inv =>
             ({text: inv.invigilator_name, value: inv.invigilator_id})
           )
+          options.push({text: 'unassigned', value: ''})
+          return options
         }
         return []
       },
@@ -239,9 +240,24 @@
               let i = this.editedFields.indexOf(e.target.name)
               this.editedFields.splice(i, 1)
             }
-            this[e.target.name] = e.target.value
+            this[name] = value
             return
           }
+        }
+        if (name === 'invigiator_id' && value == '') {
+          if (this.itemCopy.booking.invigiator_id) {
+            if (!this.editedFields.includes(name)) {
+              this.editedFields.push(name)
+            }
+          }
+          if (!this.itemCopy.booking.invigiator_id) {
+            if (this.editedFields.includes(e.target.name)) {
+              let i = this.editedFields.indexOf(e.target.name)
+              this.editedFields.splice(i, 1)
+            }
+          }
+          this.invigiator_id = ''
+          return
         }
         value = parseInt(value)
         if (value !== this.itemCopy.booking[name]) {
@@ -278,8 +294,9 @@
           let end = start.clone().add(parseInt(this.itemCopy.exam_type.number_of_hours), 'h')
           bookingChanges['start_time'] = start.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
           bookingChanges['end_time'] = end.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
-          if (this.invigilator_id) {
-            bookingChanges['invigilator_id'] = this.invigilator_id
+          bookingChanges['invigilator_id'] = this.invigilator_id
+          if (bookingChanges.invigilator_id == '') {
+            bookingChanges.invigilator_id = null
           }
           putRequests.push({url:`/bookings/${this.itemCopy.booking.booking_id}/`, data: bookingChanges})
         }

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -106,7 +106,7 @@
                            @click="editExam(row.item)">Edit Exam</b-dropdown-item>
           <b-dropdown-item size="sm"
                            @click="returnExamInfo(row.item)">Return Exam</b-dropdown-item>
-          <template v-if="row.item.booking && row.item.booking.invigilator_id">
+          <template v-if="row.item.booking&&(row.item.booking.invigilator_id||row.item.booking.sbc_staff_invigilated)">
             <b-dropdown-item v-if="row.item.offsite_location"
                              size="sm"
                              @click="editGroupExam(row.item)">Reschedule</b-dropdown-item>
@@ -290,10 +290,10 @@
               moreFiltered = filtered
               break
             case 'unscheduled':
-              moreFiltered = filtered.filter(ex => !ex.booking || !ex.booking.invigilator_id)
+              moreFiltered=filtered.filter(x=>!x.booking||(!x.booking.invigilator_id&&!x.booking.sbc_staff_invigilated))
               break
             case 'scheduled':
-              moreFiltered = filtered.filter(ex => ex.booking && ex.booking.invigilator_id)
+              moreFiltered = filtered.filter(x=>x.booking&&(x.booking.invigilator_id||x.booking.sbc_staff_invigilated))
               break
             default:
               moreFiltered = filtered

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -370,13 +370,13 @@ export const store = new Vuex.Store({
 
   getters: {
     invigilator_dropdown(state) {
-      let invigilators = state.invigilators
-      invigilators.push({invigilator_id: 'sbc', invigilator_name: 'SBC Staff'})
-      invigilators.push({invigilator_id: null, invigilator_name: 'unassigned'})
-      return invigilators.map( i =>
+      let invigilators = state.invigilators.map( i =>
         ({value: i.invigilator_id,
           text: i.invigilator_name})
       )
+      invigilators.push({value: 'sbc', text: 'SBC Staff'})
+      invigilators.push({value: null, text: 'unassigned'})
+      return invigilators
     },
     
     show_scheduling_indicator: (state) => {
@@ -2149,8 +2149,7 @@ export const store = new Vuex.Store({
       state.examTypes = payload
     },
 
-    setInvigilators(state, payload){
-      state.invigilators = []
+    setInvigilators(state, payload) {
       state.invigilators = payload
     },
 


### PR DESCRIPTION
Fixed issue which was causing exam inventory filters not to work correctly following the addition of the sbc_staff_invigilated flag to the data model.  also fixed an issue with the tabular data display in the edit-group-exam-booking-modal and a bug with the inivigilator dropdown in same.  also added the ability to PUT an 'unassigned' invigilator to a group exam.