### PR TITLE
Generate CSV Additional Filter Options

### DIFF
--- a/api/app/resources/bookings/exam/exam_export_list.py
+++ b/api/app/resources/bookings/exam/exam_export_list.py
@@ -69,14 +69,16 @@ class ExamList(Resource):
                               .join(Office, Booking.office_id == Office.office_id) \
                               .join(ExamType, Exam.exam_type_id == ExamType.exam_type_id)
 
-            if exam_type == '1':
+            if exam_type == 'ita':
                 exams = exams.filter(ExamType.ita_ind == 1)
-            elif exam_type == '2':
+            elif exam_type == 'veterinary':
                 exams = exams.filter(ExamType.exam_type_name == 'Veterinary Exam')
-            elif exam_type == '3':
+            elif exam_type == 'milk_tank':
                 exams = exams.filter(ExamType.exam_type_name == 'Milk Grader')
-            elif exam_type == '4':
+            elif exam_type == 'pesticide':
                 exams = exams.filter(ExamType.exam_type_name == 'Pesticide')
+            elif exam_type == 'all_non_ita':
+                exams = exams.filter(ExamType.ita_ind == 0)
 
             dest = io.StringIO()
             out = csv.writer(dest)

--- a/frontend/src/exams/generate-financial-report-modal.vue
+++ b/frontend/src/exams/generate-financial-report-modal.vue
@@ -59,7 +59,9 @@
             startDate: '',
             endDate: '',
             options: [
+              {text: 'All Exams', value: 'all'},
               {text: 'ITA - Individual and Group ', value: 'ita'},
+              {text: 'All Non-ITA Exams', value: 'all_non_ita'},
               {text: 'Veterinary Exam', value: 'veterinary'},
               {text: 'Milk Grader', value: 'milk_tank'},
               {text: 'Pesticide', value: 'pesticide'}
@@ -78,18 +80,8 @@
           submit() {
             let form_start_date = moment.utc(this.startDate).format('YYYY-MM-DD')
             let form_end_date = moment.utc(this.endDate).format('YYYY-MM-DD')
-            let exam_type
-            if (this.selectedExamType === 'ita'){
-              exam_type = 1
-            }else if (this.selectedExamType === 'veterinary') {
-              exam_type = 2
-            }else if (this.selectedExamType === 'milk_tank') {
-              exam_type = 3
-            }else if (this.selectedExamType === 'pesticide') {
-              exam_type = 4
-            }
             let url = '/exams/export/?start_date=' + form_start_date + '&end_date=' + form_end_date + '&exam_type='
-                      + exam_type
+                      + this.selectedExamType
             let today = moment().format('YYYY-MM-DD_HHMMSS')
             let filename = 'export-csv-' + today + '.csv'
             this.getExamsExport(url)


### PR DESCRIPTION
During testing of the generate csv modal, it was found that additional filters would be required. John McColl specifically asked for an "All Exams" option and "All Non-ITA Exams" option to be added to the filter options. These filters were added and then tested by adding multiple different exams were added in the span of a month, and then making sure that the csv generated for reported had the exact number of exams reported back that existed in the bookings calendar for that month.