### PR TITLE
Changed validation on exam form modal to require 5 digit event_id

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3994,7 +3994,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -4728,7 +4728,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4749,12 +4750,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4769,17 +4772,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4896,7 +4902,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4908,6 +4915,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4922,6 +4930,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4929,12 +4938,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4953,6 +4964,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5033,7 +5045,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5045,6 +5058,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5130,7 +5144,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5166,6 +5181,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5185,6 +5201,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5228,12 +5245,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13013,6 +13032,11 @@
           "dev": true
         }
       }
+    },
+    "vue-fragment": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.0.tgz",
+      "integrity": "sha512-nobmbbOSOx59fm7U00BDz14Yvqitwx7NPQGYDTKg3+dNDGTDCRNy/q2kfr5hV4S0l4fQG0kvC+rbCmENLmHUSA=="
     },
     "vue-full-calendar": {
       "version": "2.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "socket.io-client": "^2.1.1",
     "v-dragged": "0.0.5",
     "vue": "^2.5.22",
+    "vue-fragment": "^1.5.0",
     "vue-full-calendar": "^2.7.0",
     "vue-router": "^3.0.2",
     "vue-video-player": "^5.0.2",

--- a/frontend/src/exams/add-exam-form-confirm.vue
+++ b/frontend/src/exams/add-exam-form-confirm.vue
@@ -48,7 +48,7 @@
         <span class="confirm-item">{{ exam.exam_name }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual' || setup === 'other' ">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Writer's Name</span>
@@ -66,7 +66,7 @@
         <span class="confirm-item">{{ exam.number_of_students }}</span>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual'">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'individual' || setup === 'other' ">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Received Date</span>
@@ -129,22 +129,22 @@
         examTypes: state => state.examTypes,
         tab: state => state.captureITAExamTabSetup,
         user: state => state.user,
-        addITAExamModal: state => state.addITAExamModal,
+        addExamModal: state => state.addExamModal,
         offices: state => state.offices,
       }),
       ...mapGetters(['exam_object']),
       officeName() {
-        if (this.addITAExamModal.setup === 'group' && this.exam.office_id) {
+        if (this.addExamModal.setup === 'group' && this.exam.office_id) {
           let office = this.offices.find(o => o.office_id == this.exam.office_id)
           return `#${office.office_id} - ${office.office_name}`
         }
         return ''
       },
       setup() {
-        if (this.addITAExamModal.setup === 'individual') {
+        if (this.addExamModal.setup === 'individual') {
           return 'individual'
         }
-        if (this.addITAExamModal.setup === 'group') {
+        if (this.addExamModal.setup === 'group') {
           return 'group'
         }
       },

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -111,7 +111,7 @@
   import moment from 'moment'
 
   export default {
-    name: 'AddExamFormModal',
+    name: 'AddExamModal',
     components: { AddExamFormController, AddExamFormConfirm },
     data() {
       return ({
@@ -127,13 +127,12 @@
       ...mapState({
         exam: state => state.capturedExam,
         examTypes: state => state.examTypes,
-        addITAExamModal: state => state.addITAExamModal,
-        groupITASteps: state => state.groupITASteps,
-        indITASteps: state => state.indITASteps,
+        addExamModal: state => state.addExamModal,
         tab: state => state.captureITAExamTabSetup,
         user: state => state.user,
-        groupITASteps: state => state.addGroupITASteps,
-        indITASteps: state => state.addIndITASteps,
+        addGroupSteps: state => state.addGroupSteps,
+        addIndividualSteps: state => state.addIndividualSteps,
+        addOtherSteps: state => state.addOtherSteps,
       }),
       errors() {
         if (this.tab.errors) {
@@ -145,10 +144,10 @@
       },
       modalVisible: {
         get() {
-          return this.addITAExamModal.visible
+          return this.addExamModal.visible
         },
         set(e) {
-          this.toggleAddITAExamVisibility(e)
+          this.toggleAddExamModal(e)
         }
       },
       step() {
@@ -158,12 +157,15 @@
         return 1
       },
       steps() {
-        let { setup } = this.addITAExamModal
+        let { setup } = this.addExamModal
         if (setup === 'group') {
-          return this.groupITASteps
+          return this.addGroupSteps
+        }
+        if (setup === 'other') {
+          return this.addOtherSteps
         }
         if (setup === 'individual') {
-          return this.indITASteps
+          return this.addIndividualSteps
         }
       },
       tabs() {
@@ -187,9 +189,8 @@
         'captureExamDetail',
         'resetCaptureForm',
         'resetCaptureTab',
-        'toggleAddITAExamModal',
+        'toggleAddExamModal',
         'updateCaptureTab',
-        'toggleAddITAExamVisibility'
       ]),
       tabWarning(i) {
         if (!Array.isArray(this.errors)) return ''
@@ -219,7 +220,7 @@
       },
       clickCancel() {
         this.resetModal()
-        this.toggleAddITAExamModal({visible: false, setup: null, step1MenuOpen: false})
+        this.toggleAddExamModal({visible: false, setup: null, step1MenuOpen: false})
       },
       clickNext() {
         let step = this.step + 1
@@ -234,10 +235,17 @@
       },
       initialize() {
         this.captureExamDetail({key:'notes', value: ''})
-        if (this.addITAExamModal.setup !== 'group') {
+        if (this.addExamModal.setup !== 'group') {
           let d = new Date()
           let today = moment(d).format('YYYY-MM-DD')
           this.captureExamDetail({ key: 'exam_received_date', value: today })
+        }
+        if (this.addExamModal.setup === 'group') {
+          let { office_id, office_number } = this.user.office
+          office_id = parseInt(office_id)
+          office_number = parseInt(office_number)
+          this.captureExamDetail({key: 'office_id', value: office_id })
+          this.toggleAddExamModal({ office_number })
         }
         this.unSubmitted = true
         this.submitMsg = ''
@@ -250,7 +258,7 @@
       submit() {
         this.unSubmitted = false
         this.submitMsg = ''
-        if (this.addITAExamModal.setup === 'group') {
+        if (this.addExamModal.setup === 'group') {
           this.clickAddExamSubmit('group').then( resp => {
             this.status = resp
             this.getExams()
@@ -259,7 +267,7 @@
             this.getExams()
           })
         }
-        if (this.addITAExamModal.setup === 'individual') {
+        if (this.addExamModal.setup === 'individual') {
           this.clickAddExamSubmit('individual').then( resp => {
             this.status = resp
             this.getExams()

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -10,19 +10,19 @@
     <div style="flex-grow: 1">
       <b-button variant="primary" @click="clickGenFinReport">Generate Financial Report</b-button>
     </div>
-    <AddExamFormModal />
+    <AddExamModal />
     <FinancialReportModal />
   </div>
 </template>
 
 <script>
   import { mapMutations, mapState, mapGetters } from 'vuex'
-  import AddExamFormModal from './add-exam-form-modal'
+  import AddExamModal from './add-exam-modal'
   import FinancialReportModal from './generate-financial-report-modal'
 
   export default {
     name: "ButtonsExams",
-    components: {AddExamFormModal, FinancialReportModal },
+    components: { AddExamModal, FinancialReportModal },
     computed: {
       ...mapState([ 'user',
                     'showGenFinReportModal',
@@ -35,21 +35,18 @@
       }
     },
     methods: {
-      ...mapMutations(['toggleAddITAExamModal', 'toggleGenFinReport', 'toggleNonITAExamModal']),
+      ...mapMutations(['toggleAddExamModal', 'toggleGenFinReport',]),
       clickAddIndividual() {
-        this.toggleNonITAExamModal(false)
-        this.toggleAddITAExamModal({visible: true, setup: 'individual'})
+        this.toggleAddExamModal({visible: true, setup: 'individual'})
       },
       clickAddGroup() {
-        this.toggleNonITAExamModal(false)
-        this.toggleAddITAExamModal({visible: true, setup: 'group'})
+        this.toggleAddExamModal({visible: true, setup: 'group'})
       },
       clickGenFinReport() {
         this.toggleGenFinReport(true)
       },
       clickAddNonITA() {
-        this.toggleNonITAExamModal(true)
-        this.toggleAddITAExamModal({visible: true, setup: 'individual'})
+        this.toggleAddExamModal({visible: true, setup: 'other'})
       }
     }
   }

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -8,6 +8,7 @@
            size="md">
     <div v-if="exam">
       <b-table v-show="false"
+               v-if="role_code==='LIAISON'"
                :items="offices"
                :fields="{key: 'office_name'}"
                :filter="search"

--- a/frontend/src/exams/office-drop.vue
+++ b/frontend/src/exams/office-drop.vue
@@ -1,36 +1,48 @@
 <template>
-  <div v-if="role_code === 'LIAISON'">
-    <b-table v-show="false"
-             :items="offices"
-             :fields="{key: 'office_name'}"
-             :filter="search"
-             @filtered="getFilteredOffices" />
-    <b-form>
-      <b-form-row>
-        <b-col>
-          <b-form-group>
-            <label class="my-0">Office (Start typing below to search or enter Office Number )</label>
-            <div><b-form-input id="office_name"
-                               type="text"
-                               class="less-10-mb"
-                               :value="officeSearch"
-                               @focus.native="officeSearchOnFocus"
-                               @blur.native="officeSearchOnBlur"
-                               @input.native="handleOfficeInput" /></div>
-            <div :class="officeDropClass" style="border: 1px solid grey">
-              <template v-for="office in officeChoices">
-                <b-dropdown-item-button v-on:click.prevent="handleOfficeDropClick"
-                                        :name="office.office_name"
-                                        :value="office.office_number"
-                                        :id="office.office_id">{{ office.office_name }}
-                </b-dropdown-item-button>
-              </template>
-            </div>
-          </b-form-group>
-        </b-col>
-      </b-form-row>
-    </b-form>
-  </div>
+  <fragment>
+    <b-col :cols="columnW">
+      <b-table v-show="false"
+               v-if="role_code==='LIAISON'"
+               :items="offices"
+               :fields="{key: 'office_name'}"
+               :filter="search"
+               @filtered="getFilteredOffices" />
+      <b-form-group>
+        <label class="my-0">Office
+          <span v-if="!error"> {{ msg }} </span>
+          <span v-if="error" style="color: red"> {{ msg }} </span>
+        </label>
+        <div>
+          <b-form-input id="office_name"
+                        type="text"
+                        class="less-10-mb"
+                        :value="officeSearch"
+                        @focus.native="officeSearchOnFocus"
+                        @blur.native="officeSearchOnBlur"
+                        @input.native="handleOfficeInput" />
+        </div>
+        <div :class="officeDropClass"
+             style="border: 1px solid grey">
+          <template v-for="office in officeChoices">
+            <b-dropdown-item-button v-on:click.prevent="handleOfficeDropClick"
+                                    :name="office.office_name"
+                                    :value="office.office_number"
+                                    :id="office.office_number">{{ office.office_name }}</b-dropdown-item-button>
+          </template>
+        </div>
+      </b-form-group>
+    </b-col>
+    <b-col cols="2">
+      <b-form-group>
+        <label class="my-0">Office #</label>
+        <b-form-input id="office_number"
+                      type="number"
+                      class="less-10-mb"
+                      :value="office_number"
+                      @input.native="handleOfficeNumberInput" />
+      </b-form-group>
+    </b-col>
+  </fragment>
 </template>
 
 <script>
@@ -38,11 +50,11 @@
 
   export default {
     name: "OfficeDrop",
+    props: ['columnW', 'office_number', 'setOffice', 'msg', 'error'],
     data () {
       return {
         clickedMenu: false,
-        office_number: null,
-        office_id: null,
+        message: '',
         officeChoices: [],
         showMessage: false,
         showSearch: false,
@@ -51,8 +63,13 @@
       }
     },
     computed: {
-      ...mapGetters(['role_code']),
-      ...mapState(['offices', 'officeDropDown',]),
+      ...mapGetters([ 'role_code' ]),
+      ...mapState([ 'offices', 'capturedExam' ]),
+      office_id() {
+        if (this.capturedExam && this.capturedExam.office_id) {
+          return this.capturedExam.office_id
+        }
+      },
       officeDropClass() {
         if (!this.showSearch) {
           return 'dropdown-menu'
@@ -62,27 +79,27 @@
         }
       },
       officeSearch() {
-        if (!this.searching && this.officeDropDown) {
-          return this.offices.find(office=>office.office_number == this.office_number).office_name
+        let office_number = this.office_number
+        if (!this.searching && office_number && this.offices.find(office=>office.office_number == office_number)) {
+          return this.offices.find(office => office.office_number == this.office_number).office_name
         }
         return this.search
       },
     },
     methods: {
       ...mapActions(['getOffices',]),
-      ...mapMutations(['setOfficeDropDown']),
+      ...mapMutations([]),
       getFilteredOffices(offices) {
         if (offices.length === 0) {
-          this.officeChoices = [{office_id: null, office_name: 'No offices found with those letters'}]
+          this.officeChoices = [{office_number: null, office_name: 'No offices found with those letters'}]
           return
         }
         this.officeChoices = offices.length >= 4 ? offices.slice(0,4) : offices
       },
       handleOfficeDropClick(e) {
         this.showSearch = false
-        this.office_id = e.target.id
         this.search = e.target.name
-        this.office_number = e.target.value
+        this.setOffice(e.target.value)
         this.searching = false
       },
       handleOfficeInput(e) {
@@ -97,18 +114,12 @@
       },
       handleOfficeNumberInput(e) {
         let { value } = e.target
-        if (value.length <= 2) {
-          this.office_number = value
-        } else {
-          this.office_number = value.slice(value.length-2, value.length)
-        }
-        if (this.offices.find(office=>office.office_number == this.office_number)) {
-          let office = this.offices.find(office=>office.office_number == this.office_number)
+        this.setOffice(value)
+        if (this.offices.find(office=>office.office_number == value)) {
+          let office = this.offices.find(office=>office.office_number == value)
           this.search = office.office_name
-          this.office_id = office.office_id
         } else {
           this.search = 'Invalid office number entered.'
-          this.office_id = null
         }
       },
       officeSearchOnBlur() {
@@ -125,16 +136,5 @@
 <style scoped>
   .less-10-mb {
     margin-bottom: -10px !important;
-  }
-  .less-15-mb {
-    margin-bottom: -15px !important;
-  }
-  .id-grid-1st-col {
-    margin-left: auto;
-    margin-right: 20px;
-  }
-  .id-grid-1st-col {
-    grid-column: 1 / span 2;
-    margin-right: 20px;
   }
 </style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -18,6 +18,7 @@ import 'es6-promise/auto'
 import { store } from './store/'
 import BootstrapVue from 'bootstrap-vue'
 import Router from './router.js'
+import Fragment from 'vue-fragment'
 
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-vue/dist/bootstrap-vue.css'
@@ -53,6 +54,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import VDragged from 'v-dragged'
 
 Vue.use(VDragged)
+Vue.use(Fragment.Plugin)
 library.add(
   faClock,
   faAngleLeft,

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,7 +24,7 @@ Vue.use(Vuex)
 
 export const store = new Vuex.Store({
   state: {
-    addIndITASteps: [
+    addIndividualSteps: [
       {
         step: 1,
         title:'Exam Type',
@@ -46,7 +46,7 @@ export const store = new Vuex.Store({
             key: 'event_id',
             text:'Event ID' ,
             kind: 'input',
-            minLength: 6,
+            minLength: 5,
             digit: true,
           },
           {
@@ -66,7 +66,7 @@ export const store = new Vuex.Store({
           {
             key: 'exam_method',
             text: 'Exam Method',
-            minLength: 0,
+            minLength: 1,
             digit: false,
             kind:'select',
             options: [
@@ -85,14 +85,14 @@ export const store = new Vuex.Store({
             key: 'exam_received_date',
             text1:'Was the Exam Package Receieved Today?',
             text2: 'Date of Receipt of Exam Package',
-            minLength: 0,
+            minLength: 1,
             digit: false,
           },
           {
             kind: 'date',
             key: 'expiry_date',
             text: 'Exam Expiry Date',
-            minLength: 0,
+            minLength: 1,
             digit: false,
           },
           {
@@ -120,7 +120,103 @@ export const store = new Vuex.Store({
           ]
       },
     ],
-    addGroupITASteps: [
+    addOtherSteps: [
+      {
+        step: 1,
+        title:'Exam Type',
+        questions: [
+          {
+            key: 'exam_type_id',
+            text: 'Exam Type ID / Colour',
+            kind:'dropdown',
+            minLength: 0,
+            digit: false,
+          }
+        ]
+      },
+      {
+        step: 2,
+        title:'Exam Info',
+        questions: [
+          {
+            key: 'event_id',
+            text:'Event ID (not required)' ,
+            kind: 'input',
+            minLength: 0,
+            digit: false,
+          },
+          {
+            key: 'exam_name',
+            text: 'Exam Name',
+            kind: 'input',
+            minLength: 6,
+            digit: false
+          },
+          {
+            key: 'examinee_name',
+            text: `Exam Writer's Name`,
+            minLength: 6,
+            kind:'input',
+            digit: false
+          },
+          {
+            key: 'exam_method',
+            text: 'Exam Method',
+            minLength: 1,
+            digit: false,
+            kind:'select',
+            options: [
+              {text: 'paper', value: 'paper', id: 'exam_method'},
+              {text: 'online', value: 'online', id: 'exam_method'}
+            ]
+          },
+        ]
+      },
+      {
+        step: 3,
+        title: 'Exam Dates',
+        questions: [
+          {
+            kind: 'exam_received',
+            key: 'exam_received_date',
+            text1:'Have you received the exam package yet?',
+            text2: 'Date of Receipt of Exam Package',
+            minLength: 0,
+            digit: false,
+          },
+          {
+            kind: 'date',
+            key: 'expiry_date',
+            text: 'Exam Expiry Date',
+            minLength: 1,
+            digit: false,
+          },
+          {
+            kind: 'notes',
+            key: 'notes',
+            text: 'Additional Notes (optional)',
+            minLength: 0,
+            digit: false,
+          },
+        ]
+      },
+      {
+        step: 4,
+        title:'Summary',
+        questions:
+          [
+            {
+              kind: null,
+              key: null,
+              text1:null,
+              text2: null,
+              minLength: 0,
+              digit: false,
+            },
+          ]
+      },
+    ],
+    addGroupSteps: [
       {
         step: 1,
         title:'Exam Type',
@@ -143,29 +239,29 @@ export const store = new Vuex.Store({
             key: 'office_id',
             text: 'Office',
             kind: 'office',
-            minLength: 0,
-            digit: false,
+            minLength: 1,
+            digit: true,
           },
           {
             key: 'event_id',
             text: 'Event ID',
             kind: 'input',
-            minLength: 0,
-            digit: false
+            minLength: 5,
+            digit: true
           },
           {
             key: 'exam_name',
             text: 'Exam Name',
             kind: 'input',
-            minLength: 0,
+            minLength: 6,
             digit: false,
           },
           {
             key: 'number_of_students',
             text: 'Number of Students',
-            minLength: 0,
+            minLength: 1,
             kind: 'input',
-            digit: false
+            digit: true
           },
         ]
       },
@@ -177,34 +273,34 @@ export const store = new Vuex.Store({
             kind: 'date',
             key: 'expiry_date',
             text: 'Date and Time',
-            minLength: 0,
+            minLength: 1,
             digit: false,
           },
           {
             kind: 'time',
             key: 'exam_time',
             text: 'Exam Time',
-            minLength: 0,
-            digit: false,
-          },
-          {
-            kind: 'input',
-            key: 'offsite_location',
-            text: 'Location',
-            type: 'input',
-            minLength: 0,
+            minLength: 1,
             digit: false,
           },
           {
             key: 'exam_method',
             text: 'Exam Method',
-            minLength: 0,
+            minLength: 1,
             digit: false,
             kind: 'select',
             options: [
               { text: 'paper', value: 'paper', id: 'exam_method' },
               { text: 'online', value: 'online', id: 'exam_method' }
             ]
+          },
+          {
+            kind: 'input',
+            key: 'offsite_location',
+            text: 'Location',
+            type: 'input',
+            minLength: 6,
+            digit: false,
           },
           {
             kind: 'notes',
@@ -231,10 +327,11 @@ export const store = new Vuex.Store({
         ]
       },
     ],
-    addITAExamModal: {
+    addExamModal: {
       visible: false,
       setup: 'individual',
       step1MenuOpen: false,
+      office_number: null,
     },
     addModalForm: {
       citizen:'',
@@ -387,18 +484,6 @@ export const store = new Vuex.Store({
         return false
       }
       return false
-    },
-    
-    get_room_by_id: (state) => (id) => {
-      return state.rooms.find(room => room.id == id)
-    },
-    
-    get_exam_by_id: (state) => (id) => {
-      return state.exams.find(exam => exam.id == id)
-    },
-    
-    get_booking_by_id: (state) => (id) => {
-      return state.bookings.find(booking => booking.id = id)
     },
   
     filtered_calendar_events: (state, getters) => (search) => {
@@ -2222,18 +2307,18 @@ export const store = new Vuex.Store({
 
     setNavigation: (state, value) => state.adminNavigation = value,
   
-    toggleAddITAExamModal(state, payload) {
-      if (typeof payload === 'object') {
-        Object.keys(payload).forEach(key => {
-          Vue.set(
-            state.addITAExamModal,
-            key,
-            payload[key]
-          )
-        })
-      } else {
-        state.addITAExamModal.visible = payload
+    toggleAddExamModal(state, payload) {
+      if (typeof payload === 'boolean') {
+        state.addExamModal.visible = payload
+        return
       }
+      Object.keys(payload).forEach(key => {
+        Vue.set(
+          state.addExamModal,
+          key,
+          payload[key]
+        )
+      })
     },
 
     toggleGenFinReport(state, payload) {
@@ -2254,10 +2339,18 @@ export const store = new Vuex.Store({
       )
     },
 
-    resetCaptureForm: (state) => state.capturedExam = {},
+    resetCaptureForm(state) {
+      Object.keys(state.capturedExam).forEach(key => {
+        Vue.set(
+          state.capturedExam,
+          key,
+          null
+        )
+      })
+    },
 
     resetCaptureTab(state) {
-      let initialState = {
+      Object.entries({
         step: 1,
         highestStep: 1,
         stepsValidated: [],
@@ -2265,13 +2358,11 @@ export const store = new Vuex.Store({
         showRadio: true,
         success: '',
         notes: false
-      }
-      let keys = Object.keys(initialState)
-      keys.forEach(key => {
+      }).forEach( entry => {
         Vue.set(
           state.captureITAExamTabSetup,
-          key,
-          initialState[key]
+          entry[0],
+          entry[1]
         )
       })
     },
@@ -2308,8 +2399,6 @@ export const store = new Vuex.Store({
     setClickedDate: (state, payload) => state.clickedDate = payload,
     
     toggleExamInventoryModal: (state, payload) => state.showExamInventoryModal = payload,
-
-    toggleNonITAExamModal: (state, payload) => state.nonITAExam = payload,
 
     toggleEditExamModal: (state, payload) => state.showEditExamModal = payload,
 
@@ -2368,13 +2457,6 @@ export const store = new Vuex.Store({
   
     setSelectionIndicator: (state, payload) => state.selectionIndicator = payload,
     
-    toggleAddITAExamVisibility(state, payload) {
-      Vue.set(
-        state.addITAExamModal,
-        'visible',
-        payload
-      )
-    },
     setGroupBookings: (state, payload) => state.groupBookings = payload,
   
     setResources: (state, payload) => state.roomResources = payload,


### PR DESCRIPTION
Created an additional questions object in store for capture 'other' exam workflow, and edited the existing questions objects to require only 5 digit event_id numbers.  Refactored validation logic to allow for setting optional fields (minLength: 0, digits: false), and swapped in new office selection component.