### PR TITLE
Changed wording in 'Schedule an Event' dropdown menu on Room Booking component

### DIFF
--- a/frontend/src/booking/buttons-calendar.vue
+++ b/frontend/src/booking/buttons-calendar.vue
@@ -18,10 +18,10 @@
                   class="mr-3 ml-3"
                   text="Schedule an Event...">
         <b-dropdown-item @click="showExamModal">
-          ITA Exam
+          Exam Event
         </b-dropdown-item>
         <b-dropdown-item @click="scheduleOtherEvent">
-          Non-exam/Other Event
+          Non-Exam Event
         </b-dropdown-item>
       </b-dropdown>
     </form>


### PR DESCRIPTION
Since the ITA Exam Event option is for all exam types, renamed the button in the dropdown menu to 'Exam Event'.