### PR TITLE
Modified booking schema to allow invigilator_id to be null

### DIFF
--- a/api/app/schemas/bookings/booking_schema.py
+++ b/api/app/schemas/bookings/booking_schema.py
@@ -32,7 +32,7 @@ class BookingSchema(ma.ModelSchema):
     fees = fields.Str()
     room_id = fields.Int()
     start_time = fields.DateTime()
-    invigilator_id = fields.Int()
+    invigilator_id = fields.Int(allow_none=True)
     office_id = fields.Int()
     sbc_staff_invigilated = fields.Int()
 


### PR DESCRIPTION
Added the 'allow_none=True' flag to invigilator_id in the bookings schema to allow the field to be set to null now that the sbc_staff_invigilated flag has been implemented (therefor creating the practical need for updating the invigilator to null from a previously set value)