### PR TITLE
Return Exam Functionality

### DIFF
--- a/frontend/src/exams/return-exam-form-modal.vue
+++ b/frontend/src/exams/return-exam-form-modal.vue
@@ -7,7 +7,9 @@
            @hidden="ok"
            @ok="submit"
            size="md">
-      <b-container style="font-size:1.1rem; border:1px solid lightgrey; border-radius: 10px" class="mb-2 pb-3" fluid>
+      <b-container style="font-size:1.1rem; border:1px solid lightgrey; border-radius: 10px"
+                   class="mb-2 pb-3"
+                   fluid>
           <b-row>
               <b-col>
                   <h3>Return Exam Form</h3>
@@ -16,14 +18,22 @@
           <b-row class="my-1">
               <b-col sm="4"><label>Exam Returned: </label></b-col>
               <b-col sm="7">
-                  <select class="form-control" name="examReturned" v-model=selectedReturned>
-                      <option v-for="returned in examReturnedOptions" :value="returned.value">{{ returned.value }}</option>
+                  <select class="form-control"
+                          name="examReturned"
+                          v-model=selectedReturned>
+                      <option v-for="returned in examReturnedOptions"
+                              :value="returned.value">{{ returned.value }}
+                      </option>
                   </select>
               </b-col>
           </b-row>
           <b-row>
               <b-col sm="4"><label>Tracking Number: </label></b-col>
-              <b-col sm="7"><b-form-input id="trackingNumber" type="text" v-model=fields.exam_returned_tracking_number></b-form-input></b-col>
+              <b-col sm="7">
+                <b-form-input id="trackingNumber"
+                              type="text"
+                              v-model=fields.exam_returned_tracking_number>
+              </b-form-input></b-col>
           </b-row>
       </b-container>
   </b-modal>
@@ -34,7 +44,6 @@
     export default {
         name: "ReturnExamModal",
         mounted() {
-            this.selectedExam.exam_id = this.fields.exam_id;
             if(this.fields.exam_returned_ind === 0) {
                   this.selectedReturned = 'No';
             }else if (this.fields.exam_returned_ind === 1) {
@@ -72,29 +81,24 @@
             submit() {
                 this.setEditExamSuccess(false)
                 this.setEditExamFailure(false)
-                this.selectedExam.exam_id = this.fields.exam_id;
                 if(this.selectedReturned === 'No') {
                     this.selectedReturned = 0;
                 } else {
                     this.selectedReturned = 1;
                 }
                 let return_exam = {
-                    exam_id: this.selectedExam.exam_id,
+                    exam_id: this.fields.exam_id,
                     exam_returned_ind: this.selectedReturned,
+                    exam_returned_tracking_number: this.fields.exam_returned_tracking_number
                 }
-
-                if (this.fields.exam_returned_tracking_number) {
-                  return_exam.exam_returned_tracking_number = this.fields.exam_returned_tracking_number
-                }
-                this.putExamInfo(return_exam);
-                this.getExams();
+                this.putExamInfo(return_exam)
+                  .then(() => { this.getExams() })
             },
         },
         computed: {
             ...mapState({
                 showReturnExamModalVisible: state => state.showReturnExamModalVisible,
-                fields: state => state.returnExams,
-                selectedExam: state => state.selectedExam,
+                fields: state => state.returnExam,
                 editExamSuccess: state => state.editExamSuccess,
                 editExamFailure: state => state.editExamFailure,
             }),

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -310,7 +310,7 @@ export const store = new Vuex.Store({
     officeType: null,
     performingAction: false,
     rescheduling: false,
-    returnExams: [],
+    returnExam: null,
     rooms: [],
     roomResources: [],
     scheduling: false,
@@ -2317,7 +2317,7 @@ export const store = new Vuex.Store({
 
     setEditExamInfo: (state, payload) => state.editExams = payload,
 
-    setReturnExamInfo: (state, payload) => state.returnExams = payload,
+    setReturnExamInfo: (state, payload) => state.returnExam = payload,
 
     setExamMethods: (state, payload) => state.examMethods = payload,
 


### PR DESCRIPTION
During testing it was found that the return exam functionality in the exam inventory table was broken. The process to break this function was to create an exam, book the exam and then return the exam immediately after booking. This was fixed by removing the selectedExam state from the return exam form modal and access the fields object instead.