### PR TITLE
Delete Exam Functionality

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4728,8 +4728,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4750,14 +4749,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4772,20 +4769,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4902,8 +4896,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4915,7 +4908,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4930,7 +4922,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4938,14 +4929,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4964,7 +4953,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5045,8 +5033,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5058,7 +5045,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5144,8 +5130,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5181,7 +5166,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5201,7 +5185,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5245,14 +5228,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5267,7 +5248,7 @@
     },
     "fullcalendar-scheduler": {
       "version": "1.9.4",
-      "resolved": "http://registry.npmjs.org/fullcalendar-scheduler/-/fullcalendar-scheduler-1.9.4.tgz",
+      "resolved": "https://registry.npmjs.org/fullcalendar-scheduler/-/fullcalendar-scheduler-1.9.4.tgz",
       "integrity": "sha512-QJ5p/qRnK+vuiNRTbsxKCytiCu2adUn1dSlRSlPSivR/FOUL4J5XQA/4o/h6YCpIMWnmLTXPOuyqBTbsG3ydyg==",
       "requires": {
         "fullcalendar": "~3.9.0",
@@ -8401,7 +8382,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -13299,7 +13280,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "requires": {
@@ -13574,7 +13555,7 @@
     },
     "yargs": {
       "version": "6.6.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
       "requires": {
@@ -13640,7 +13621,7 @@
     },
     "yargs-parser": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {

--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -164,13 +164,13 @@
               <b-form-group>
                 <label>Delete Booking?</label><br>
                 <b-btn class="w-100 btn-danger"
-                       @click="confirm = true">Delete</b-btn>
+                       @click="confirm = true">Delete Booking</b-btn>
               </b-form-group>
             </b-col>
             <b-col>
               <b-form-group>
                 <label>Change Date, Time or Room?</label><br>
-                <b-btn class="w-100 mb-0" @click="reschedule">Reschedule</b-btn>
+                <b-btn class="w-100 mb-0" @click="reschedule">Reschedule Booking</b-btn>
               </b-form-group>
             </b-col>
           </b-form-row>

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -82,7 +82,7 @@
                  align-h="center"
                  align-content="center">
             <b-col>
-              <p><h5>Success.  Exam Details Added.</h5></p>
+              <h5>Success.  Exam Details Added.</h5>
               <p><b-button @click="resetModal" class="btn-primary">Log Another Exam</b-button></p>
             </b-col>
           </b-row>

--- a/frontend/src/exams/delete-exam-modal.vue
+++ b/frontend/src/exams/delete-exam-modal.vue
@@ -1,0 +1,76 @@
+<template>
+    <b-modal v-model="deleteModalVisible"
+             :no-close-on-backdrop="true"
+             hide-header
+             hide-footer
+             hide-cancel
+             size="md">
+        <b-container style="font-size:1.1rem;">
+          <label>Are you sure you want to delete this Exam?</label>
+          <div style="font-size:0.9rem; display:flex; justify-content:center;">
+            <b-col>
+              <ul><b>Exam Name:</b> {{ fields.exam_name }}</ul>
+              <ul><b>Examinee Name:</b> {{ fields.examinee_name }}</ul>
+              <ul><b>Event ID:</b> {{ fields.event_id }}</ul>
+            </b-col>
+          </div>
+          <b-row>
+            <b-col>
+              <b-form-group>
+                <b-btn class="w-100 btn-danger"
+                       @click="clickNo">No</b-btn>
+              </b-form-group>
+            </b-col>
+            <b-col>
+              <b-form-group>
+                <b-btn class="w-100 btn-primary"
+                       @click="clickYes">Yes</b-btn>
+              </b-form-group>
+            </b-col>
+          </b-row>
+        </b-container>
+    </b-modal>
+</template>
+
+<script>
+    import { mapActions, mapMutations, mapState } from 'vuex'
+    export default {
+        name: "DeleteExamModal",
+        methods: {
+          ...mapActions([
+            'deleteExam',
+            'getExams'
+          ]),
+          ...mapMutations([
+            'toggleDeleteExamModalVisible'
+          ]),
+          clickYes() {
+            let id = this.fields.exam_id
+            this.deleteExam(id)
+              .then(() => { this.getExams() })
+            this.toggleDeleteExamModalVisible(false)
+          },
+          clickNo() {
+            this.toggleDeleteExamModalVisible(false)
+          }
+        },
+        computed: {
+            ...mapState({
+              showDeleteExamModal: state => state.showDeleteExamModal,
+              fields: state => state.returnExam,
+            }),
+            deleteModalVisible: {
+                get() {
+                    return this.showDeleteExamModal
+                },
+                set(e) {
+                    this.toggleDeleteExamModalVisible(e)
+                }
+            }
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -124,6 +124,8 @@
           <b-dropdown-item v-if="row.item.offsite_location && !(row.item.booking && row.item.booking.invigilator_id)"
                            size="sm"
                            @click="editGroupExam(row.item)">Add Invigilator</b-dropdown-item>
+          <b-dropdown-item size="sm"
+                           @click="deleteExam(row.item)">Delete Exam</b-dropdown-item>
         </b-dropdown>
       </template>
     </b-table>
@@ -137,10 +139,12 @@
     <EditExamModal :examRow="examRow" :resetExam="resetEditedExam" />
     <ReturnExamModal v-if="showReturnExamModalVisible" />
     <EditGroupExamBookingModal :examRow="examRow" :resetExam="resetEditedExam" />
+    <DeleteExamModal v-if="showDeleteExamModal" />
   </div>
 </template>
 
 <script>
+  import DeleteExamModal from './delete-exam-modal'
   import EditExamModal from './edit-exam-form-modal'
   import EditGroupExamBookingModal from './edit-group-exam-modal'
   import FailureExamAlert from './failure-exam-alert'
@@ -152,7 +156,8 @@
 
   export default {
     name: "ExamInventoryTable",
-    components: { EditGroupExamBookingModal, EditExamModal, ReturnExamModal, SuccessExamAlert, FailureExamAlert },
+    components: { EditGroupExamBookingModal, EditExamModal, ReturnExamModal, SuccessExamAlert, FailureExamAlert,
+                  DeleteExamModal },
     props: ['mode'],
     mounted() {
       this.getInvigilators()
@@ -180,6 +185,7 @@
         'calendarEvents',
         'exams',
         'inventoryFilters',
+        'showDeleteExamModal',
         'showEditExamModal',
         'showExamInventoryModal',
         'showReturnExamModalVisible',
@@ -240,6 +246,7 @@
         'setInventoryFilters',
         'setReturnExamInfo',
         'setSelectedExam',
+        'toggleDeleteExamModalVisible',
         'toggleEditBookingModal',
         'toggleEditExamModal',
         'toggleEditGroupBookingModal',
@@ -261,6 +268,11 @@
           this.$router.push('/booking')
           this.toggleExamInventoryModal(false)
         }
+      },
+      deleteExam(item) {
+        this.examRow = item
+        this.toggleDeleteExamModalVisible(true)
+        this.setReturnExamInfo(item)
       },
       editExam(item) {
         Object.keys(item).forEach( i => {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -431,6 +431,7 @@ export const store = new Vuex.Store({
     showAddModal: false,
     showAdmin: false,
     showBookingModal: false,
+    showDeleteExamModal: false,
     showEditBookingModal: false,
     showEditGroupBookingModal: false,
     showEditExamModal: false,
@@ -700,7 +701,18 @@ export const store = new Vuex.Store({
           })
       })
     },
-    
+
+    deleteExam(context, id) {
+      return new Promise((resolve, reject) => {
+        Axios(context).delete(`/exams/${id}/`).then(resp => {
+          resolve(resp.data)
+        })
+          .catch(error => {
+            reject(error)
+          })
+      })
+    },
+
     putRequest(context, payload) {
       return new Promise((resolve, reject) => {
         Axios(context).put(payload.url, payload.data).then( () => {
@@ -2403,6 +2415,8 @@ export const store = new Vuex.Store({
     toggleEditExamModal: (state, payload) => state.showEditExamModal = payload,
 
     toggleReturnExamModalVisible: (state, payload) => state.showReturnExamModalVisible = payload,
+
+    toggleDeleteExamModalVisible: (state, payload) => state.showDeleteExamModal = payload,
 
     setEditExamInfo: (state, payload) => state.editExams = payload,
 


### PR DESCRIPTION
During testing, it was found out that the bookings feature lacked a function to delete an exam, not just the exam's booking. The exam-inventory table was modified to have a 'delete exam' dropdown action, which opens a confirmation modal. This modal displays basic exam information to the user before the user deletes the exam. This function has been tested using the CSR, GA and LIAISON roles.