### PR TITLE
Add Exam Inventory Filter - Returned Exams

### DIFF
--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -47,6 +47,17 @@
                  :pressed="inventoryFilters.groupFilter==='group'"
                  @click="handleFilter({type:'groupFilter', value:'group'})">Group</b-btn>
         </b-btn-group>
+        <b-btn-group horizontal class="ml-2 pt-2">
+          <b-btn size="sm"
+                 :pressed="inventoryFilters.returnedFilter==='both'"
+                 @click="handleFilter({type:'returnedFilter', value:'both'})"><span class="mx-2">Both</span></b-btn>
+          <b-btn size="sm"
+                 :pressed="inventoryFilters.returnedFilter==='returned'"
+                 @click="handleFilter({type:'returnedFilter', value:'returned'})">Returned</b-btn>
+          <b-btn size="sm"
+                 :pressed="inventoryFilters.returnedFilter==='notReturned'"
+                 @click="handleFilter({type:'returnedFilter', value:'notReturned'})">Not Returned</b-btn>
+        </b-btn-group>
       </b-input-group>
     </b-form>
   </div>
@@ -441,7 +452,22 @@
               evenMoreFiltered = moreFiltered
               break
           }
-          return evenMoreFiltered
+          let manyMoreFiltered = []
+          switch (this.inventoryFilters.returnedFilter) {
+            case 'both':
+              manyMoreFiltered = evenMoreFiltered
+              break
+            case 'returned':
+              manyMoreFiltered = evenMoreFiltered.filter(ex => ex.exam_returned_ind === 1)
+              break
+            case 'notReturned':
+              manyMoreFiltered = evenMoreFiltered.filter(ex => ex.exam_returned_ind === 0)
+              break
+            default:
+              manyMoreFiltered = evenMoreFiltered
+              break
+          }
+          return manyMoreFiltered
         }
         return []
       },

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -503,6 +503,7 @@ export const store = new Vuex.Store({
       expiryFilter: 'current',
       scheduledFilter: 'unscheduled',
       groupFilter: 'both',
+      returnedFilter: 'notReturned',
       office_number: 'default',
     },
     nowServing: false,


### PR DESCRIPTION
During testing of the exam inventory table, it was found that the table required filters for exams that have been returned and exams that haven't been returned.Using infrastructure previously developed for filters that already exist, exams were filtered based on whether or not exam_returned_ind was 1 or 0 for the exams present in the table.