### PR TITLE
Pesticide Button/Modal Removal

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -342,8 +342,9 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
         let exams = this.examTypes.filter(type => type.exam_type_name.includes('Single'))
         return exams.sort((a,b) => sorter(a,b))
       }
+      // TODO reimplement filter for Pesticides when they are re-activated
       if(this.addExamModal.setup === 'other') {
-        let exams = this.examTypes.filter(type  => type.ita_ind === 0 && !type.exam_type_name.includes('Pesticide') )
+        let exams = this.examTypes.filter(type  => type.ita_ind === 0)
         return exams.sort((a,b) => sorter(a,b))
       }
       if (this.addExamModal.setup === 'group') {

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -9,10 +9,11 @@
                   class="mr-1 btn-primary"
                   @click="clickAddNonITA">Add Non-ITA Exam</b-button>
         <b-button v-if="role_code==='LIAISON' && financial_designate === 0 "
-                  class="btn-primary"
+                  class="mr-1 btn-primary"
                   @click="clickAddGroup">Add Group Exam</b-button>
-        <b-button v-if="pesticide_designate === 1 && financial_designate === 0"
-                  class="btn-primary"
+        <!-- TODO re-implement v-if="pesticide_designate === 1 && financial_designate === 0" when pesticide modal is re-activated -->
+        <b-button v-if="1 == 0"
+                  class="mr-1 btn-primary"
                   @click="clickAddPesticide">Add Pesticide Exam</b-button>
       </b-form>
     </div>


### PR DESCRIPTION
After client testing, it was deemed necessary that the pesticide modal and button be removed and that old pesticide non-ita exams functionality be re-implemented. The button and modal and essentially been de-activated because they will be re-used at a later date for BC Mail Plus purposes.