### PR TITLE
Financial Reporting Filter Options

### DIFF
--- a/api/app/resources/bookings/exam/exam_export_list.py
+++ b/api/app/resources/bookings/exam/exam_export_list.py
@@ -71,18 +71,13 @@ class ExamList(Resource):
 
             if exam_type == 'ita':
                 exams = exams.filter(ExamType.ita_ind == 1)
-            elif exam_type == 'veterinary':
-                exams = exams.filter(ExamType.exam_type_name == 'Veterinary Exam')
-            elif exam_type == 'milk_tank':
-                exams = exams.filter(ExamType.exam_type_name == 'Milk Grader')
-            elif exam_type == 'pesticide':
-                exams = exams.filter(ExamType.exam_type_name == 'Pesticide')
             elif exam_type == 'all_non_ita':
                 exams = exams.filter(ExamType.ita_ind == 0)
 
             dest = io.StringIO()
             out = csv.writer(dest)
-            out.writerow(['Office Name', 'Exam Type', 'Exam ID', 'Exam Name', 'Examinee Name', 'Event ID', 'Room Name', 'Invigilator Name', 'Booking ID', 'Booking Name', 'Exam Received', 'Exam Returned' ])
+            out.writerow(['Office Name', 'Exam Type', 'Exam ID', 'Exam Name', 'Examinee Name', 'Event ID', 'Room Name',
+                          'Invigilator Name', 'Booking ID', 'Booking Name', 'Exam Received', 'Exam Returned'])
 
             keys = [
                 "office_name",

--- a/frontend/src/exams/generate-financial-report-modal.vue
+++ b/frontend/src/exams/generate-financial-report-modal.vue
@@ -62,9 +62,6 @@
               {text: 'All Exams', value: 'all'},
               {text: 'ITA - Individual and Group ', value: 'ita'},
               {text: 'All Non-ITA Exams', value: 'all_non_ita'},
-              {text: 'Veterinary Exam', value: 'veterinary'},
-              {text: 'Milk Grader', value: 'milk_tank'},
-              {text: 'Pesticide', value: 'pesticide'}
             ],
             selectedExamType: '',
           }


### PR DESCRIPTION
During client testing, it was found that there were only three options required for reporting. All exams, All ITA exams, and All Non-ITA exams. All remaining filtering options were removed from the generate csv modal and exam_export_list endpoint.