### PR TITLE
Add Exam Field Length

### DIFF
--- a/frontend/src/exams/add-exam-form-controller.vue
+++ b/frontend/src/exams/add-exam-form-controller.vue
@@ -265,7 +265,6 @@
     watch: {
       step(newV, oldV) {
         if (oldV == 2 && newV == 3 && this.addExamModal.setup === 'other') {
-          console.log('hererererere uuuuuu')
           setTimeout(()=>{this.validate()}, 200)
         }
       }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -53,13 +53,13 @@ export const store = new Vuex.Store({
             key: 'exam_name',
             text: 'Exam Name',
             kind: 'input',
-            minLength: 6,
+            minLength: 2,
             digit: false
           },
           {
             key: 'examinee_name',
             text: `Exam Writer's Name`,
-            minLength: 6,
+            minLength: 2,
             kind:'input',
             digit: false
           },
@@ -149,13 +149,13 @@ export const store = new Vuex.Store({
             key: 'exam_name',
             text: 'Exam Name',
             kind: 'input',
-            minLength: 6,
+            minLength: 2,
             digit: false
           },
           {
             key: 'examinee_name',
             text: `Exam Writer's Name`,
-            minLength: 6,
+            minLength: 2,
             kind:'input',
             digit: false
           },
@@ -356,7 +356,7 @@ export const store = new Vuex.Store({
             key: 'exam_name',
             text: 'Exam Name',
             kind: 'input',
-            minLength: 6,
+            minLength: 2,
             digit: false,
           },
           {
@@ -402,7 +402,7 @@ export const store = new Vuex.Store({
             key: 'offsite_location',
             text: 'Location',
             type: 'input',
-            minLength: 6,
+            minLength: 2,
             digit: false,
           },
           {


### PR DESCRIPTION
During client testing, it was found out that all fields that require actual char input (exam name, student name etc.) only required a minimum field length of 2 chars. This was addressed in this PR.