### PR TITLE
New Delete Exams and Related Booking

### DIFF
--- a/frontend/src/exams/delete-exam-modal.vue
+++ b/frontend/src/exams/delete-exam-modal.vue
@@ -1,0 +1,86 @@
+<template>
+    <b-modal v-model="deleteModalVisible"
+             :no-close-on-backdrop="true"
+             hide-header
+             hide-footer
+             hide-cancel
+             size="md">
+        <b-container>
+          <h5>Are you sure you want to delete this Exam?</h5>
+          <div style="font-size:0.9rem; display:flex; justify-content:center;">
+            <b-col>
+              <ul><b>Exam Name: {{ this.returnExam.exam_name }}</b></ul>
+              <ul><b>Examinee Name:</b> {{ this.returnExam.examinee_name }}</ul>
+              <ul><b>Event ID:</b>{{ this.returnExam.event_id }}</ul>
+            </b-col>
+          </div>
+          <b-row>
+            <b-col>
+              <b-form-group>
+                <b-btn class="w-100 btn-danger"
+                       @click="clickNo">No</b-btn>
+              </b-form-group>
+            </b-col>
+            <b-col>
+              <b-form-group>
+                <b-btn class="w-100 btn-primary"
+                       @click="clickYes">Yes</b-btn>
+              </b-form-group>
+            </b-col>
+          </b-row>
+        </b-container>
+    </b-modal>
+</template>
+
+<script>
+    import { mapActions, mapMutations, mapState } from 'vuex'
+    export default {
+        name: "DeleteExamModal",
+        methods: {
+          ...mapActions([
+            'deleteBooking',
+            'deleteExam',
+            'getExams',
+          ]),
+          ...mapMutations([
+            'toggleDeleteExamModalVisible'
+          ]),
+          clickYes() {
+            let exam_id = this.returnExam.exam_id
+            this.deleteExam(exam_id)
+                .then(() => { this.getExams() })
+            this.toggleDeleteExamModalVisible(false)
+            if (this.returnExam.booking_id){
+              this.deleteBooking(this.returnExam.booking_id)
+            }
+          },
+          clickNo() {
+            this.toggleDeleteExamModalVisible(false)
+          }
+        },
+        computed: {
+            ...mapState({
+              showDeleteExamModal: state => state.showDeleteExamModal,
+              returnExam: state => state.returnExam,
+            }),
+            deleteModalVisible: {
+                get() {
+                    return this.showDeleteExamModal
+                },
+                set(e) {
+                    this.toggleDeleteExamModalVisible(e)
+                }
+            },
+            exam() {
+              if(Object.keys(this.examRow).length > 0){
+                return this.examRow
+              }
+              return false
+            }
+        }
+    }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -240,7 +240,10 @@
            class="mb-3"
            style="color: red;">{{ this.message }}</div>
       <div style="display: flex; justify-content: flex-end; width: 100%">
-        <b-btn class="btn-secondary mr-2" @click="toggleEditExamModal(false)">Cancel</b-btn>
+        <b-btn class="btn-danger mr-2"
+               @click="deleteExam()">Delete Exam</b-btn>
+        <b-btn class="btn-secondary mr-2"
+               @click="toggleEditExamModal(false)">Cancel</b-btn>
         <b-btn v-if="!allowSubmit()"
                class="btn-primary disabled"
                @click="setMessage">Submit</b-btn>
@@ -257,10 +260,12 @@
   import DatePicker from 'vue2-datepicker'
   import moment from 'moment'
   import Vue from 'vue'
+  import DeleteExamModal from './delete-exam-modal'
 
   export default {
     name: "EditExamModal",
-    components: { DatePicker },
+    components: { DatePicker,
+                  DeleteExamModal},
     props: ['examRow', 'resetExam'],
     data () {
       return {
@@ -286,7 +291,12 @@
     },
     computed: {
       ...mapGetters(['exam_object_id', 'role_code']),
-      ...mapState(['editExamFailure', 'editExamSuccess', 'examTypes', 'offices', 'showEditExamModal',]),
+      ...mapState(['editExamFailure',
+                   'editExamSuccess',
+                   'examTypes',
+                   'offices',
+                   'showEditExamModal',
+                   'showDeleteExamModal', ]),
       exam() {
         if (Object.keys(this.examRow).length > 0) {
           return this.examRow
@@ -378,7 +388,13 @@
     },
     methods: {
       ...mapActions(['getBookings', 'getExams', 'getOffices', 'putExamInfo',]),
-      ...mapMutations(['setEditExamFailure', 'setEditExamSuccess', 'setSelectedExam', 'toggleEditExamModal',]),
+      ...mapMutations(['setEditExamFailure',
+                       'setEditExamSuccess',
+                       'setSelectedExam',
+                       'setReturnExamInfo',
+                       'setReturnDeleteExamInfo',
+                       'toggleEditExamModal',
+                       'toggleDeleteExamModalVisible']),
       allowSubmit() {
         if (this.examRow) {
           let fieldsEdited = false
@@ -393,6 +409,29 @@
           return fieldsEdited
         }
         return false
+      },
+      deleteExam() {
+        let deleteExamInfo = {}
+
+        if (this.fields.booking_id) {
+          deleteExamInfo = {
+            booking_id: this.fields.booking_id,
+            exam_id: this.fields.exam_id,
+            exam_name: this.fields.exam_name,
+            examinee_name: this.fields.examinee_name,
+            event_id: this.fields.event_id,
+          }
+        }else {
+          deleteExamInfo = {
+            booking_id: null,
+            exam_id: this.fields.exam_id,
+            exam_name: this.fields.exam_name,
+            examinee_name: this.fields.examinee_name,
+            event_id: this.fields.event_id,
+          }
+        }
+        this.toggleDeleteExamModalVisible(true)
+        this.setReturnExamInfo(deleteExamInfo)
       },
       getFilteredOffices(offices) {
         if (offices.length === 0) {

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -203,10 +203,12 @@
   import OfficeDrop from './office-drop'
   import ReturnExamModal from './return-exam-form-modal'
   import SuccessExamAlert from './success-exam-alert'
+  import DeleteExamModal from './delete-exam-modal'
 
   export default {
     name: "ExamInventoryTable",
     components: {
+      DeleteExamModal,
       EditExamModal,
       EditGroupExamBookingModal,
       FailureExamAlert,


### PR DESCRIPTION
During client testing, it was noted that delete functionality had to be moved from the exam inventory actions dropdown list to the edit exam details modal. This functionality was also required to delete any bookings that the selected deleted exam was associated to. This functionality was tested on booked and un-booked exams that included ITA, Non-ITA and Group exams.