### PR TITLE
Create/Update/Delete Invigilators/Rooms Per Office

### DIFF
--- a/api/app/admin/__init__.py
+++ b/api/app/admin/__init__.py
@@ -22,3 +22,6 @@ from .office import OfficeModelView
 from .role import RoleModelView
 from .service import ServiceModelView
 from .smartboard import SmartBoardModelView
+from .invigilator import InvigilatorModelView
+from .room import RoomModelView
+

--- a/api/app/admin/invigilator.py
+++ b/api/app/admin/invigilator.py
@@ -1,0 +1,84 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+from app.models.bookings import Invigilator
+from .base import Base
+from flask_login import current_user
+from qsystem import db
+
+
+class InvigilatorConfig(Base):
+    roles_allowed = ['SUPPORT', 'LIAISON']
+
+    @property
+    def can_create(self):
+        return current_user.role.role_code != 'GA'
+
+    def is_accessible(self):
+        return current_user.is_authenticated and current_user.role.role_code in self.roles_allowed
+
+    def get_query(self):
+        return self.session.query(self.model).filter_by(office_id=current_user.office_id)
+
+    create_modal = False
+    edit_modal = False
+    column_list = [
+        'office.office_name',
+        'invigilator_name',
+        'contact_phone',
+        'contact_email',
+        'contract_number',
+        'contract_expiry_date',
+        'invigilator_notes'
+    ]
+
+    form_excluded_columns = [
+        'bookings'
+    ]
+
+    column_labels = {'office.office_name': 'Office Name'}
+
+    column_searchable_list = {'invigilator_name'}
+
+    form_create_rules = (
+        'office',
+        'invigilator_name',
+        'contact_phone',
+        'contact_email',
+        'contract_number',
+        'contract_expiry_date',
+        'invigilator_notes'
+    )
+
+    form_edit_rules = (
+        'office',
+        'invigilator_name',
+        'contact_phone',
+        'contact_email',
+        'contract_number',
+        'contract_expiry_date',
+        'invigilator_notes'
+    )
+
+    column_sortable_list = [
+        'invigilator_name',
+        'contact_email',
+        'contract_number',
+        'contract_expiry_date'
+    ]
+
+    column_default_sort = 'invigilator_name'
+
+
+InvigilatorModelView = InvigilatorConfig(Invigilator, db.session)

--- a/api/app/admin/room.py
+++ b/api/app/admin/room.py
@@ -1,0 +1,71 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+from app.models.bookings import Room
+from .base import Base
+from flask_login import current_user
+from qsystem import db
+
+
+class RoomConfig(Base):
+    roles_allowed = ['SUPPORT', 'LIAISON']
+
+    @property
+    def can_create(self):
+        return current_user.role.role_code != 'GA'
+
+    def is_accessible(self):
+        return current_user.is_authenticated and current_user.role.role_code in self.roles_allowed
+
+    def get_query(self):
+        return self.session.query(self.model).filter_by(office_id=current_user.office_id)
+
+    create_modal = False
+    edit_modal = False
+    column_list = [
+        'office.office_name',
+        'room_name',
+        'capacity',
+        'color'
+    ]
+
+    form_excluded_columns = [
+        'sb',
+        'booking'
+    ]
+
+    column_labels = {'office.office_name': 'Office Name'}
+
+    form_create_rules = (
+        'office',
+        'room_name',
+        'capacity',
+        'color'
+    )
+
+    form_edit_rules = (
+        'office',
+        'room_name',
+        'capacity',
+        'color'
+    )
+
+    column_sortable_list = [
+        'room_name',
+        'capacity',
+        'color'
+    ]
+
+
+RoomModelView = RoomConfig(Room, db.session)

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -69,10 +69,12 @@ flask_admin = Admin(application, name='Admin Console', template_mode='bootstrap3
 
 flask_admin.add_view(admin.ChannelModelView)
 flask_admin.add_view(admin.CSRModelView)
+flask_admin.add_view(admin.InvigilatorModelView)
 flask_admin.add_view(admin.OfficeModelView)
 flask_admin.add_view(admin.RoleModelView)
 flask_admin.add_view(admin.ServiceModelView)
 flask_admin.add_view(admin.SmartBoardModelView)
+flask_admin.add_view(admin.RoomModelView)
 flask_admin.add_link(admin.LoginMenuLink(name='Login', category='', url="/api/v1/login/"))
 flask_admin.add_link(admin.LogoutMenuLink(name='Logout', category='', url="/api/v1/logout/"))
 

--- a/frontend/src/buttons-admin.vue
+++ b/frontend/src/buttons-admin.vue
@@ -43,6 +43,8 @@
           {value: 'role', text: 'User roles'},
           {value: 'service', text: 'Provided Services'},
           {value: 'smartboard', text: 'Smartboard Content'},
+          {value: 'invigilator', text: 'Invigilators'},
+          {value: 'room', text: 'Rooms'}
         ]
       }
     },


### PR DESCRIPTION
Client requirements asked for new flask-admin panels for invigilators and rooms. Through these panels, users should be able to see a list of all rooms or all invigilators specific to the users office (not ALL rooms or ALL invigilators). This list of office specific rooms or office specific invigilators should have the ability to update and delete room records or invigilator records, and the admin panel should give the user the ability to create new rooms and invigilators as well.