### PR TITLE
Various fixes for IE11 Comptability

### DIFF
--- a/frontend/src/assets/css/q.css
+++ b/frontend/src/assets/css/q.css
@@ -41,16 +41,19 @@
    height: 100%;
    width: 100%;
    padding: 4px;
+   overflow: hidden;
  }
 .q-id-grid-outer {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  overflow: hidden;
 }
 .q-id-grid-col {
   margin-left: 4px;
   margin-right: 4px;
   display: flex;
   justify-content: space-between;
+
 }
 .q-id-grid-full-col {
   margin-left: 4px;
@@ -58,17 +61,21 @@
   display: flex;
   justify-content: space-between;
   grid-column: 1 / span 2;
+  overflow: hidden;
 }
 .q-id-grid-title {
   font-weight: normal;
+  overflow: hidden;
 }
 .q-id-grid-item {
   font-weight: lighter;
+  overflow: hidden;
 }
 .q-id-grid-head {
   margin-right: auto;
   margin-left: 5px;
   grid-column: 1 / span 2;
+  overflow: hidden;
 }
 .q-sum-td-outer-flex {
   margin: 0px;
@@ -95,4 +102,10 @@
   width: 100%;
   display: flex;
   justify-content: flex-start;
+}
+.q-modal-header {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 0px;
+  margin-bottom: 15px;
 }

--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -69,7 +69,7 @@
               <b-form-group>
                 <label>Collect Fees</label><br>
                 <b-select v-model="fees"
-                          @input.native="checkValue"
+                          @change="checkValue"
                           :options="feesOptions" />
               </b-form-group>
             </b-col>
@@ -213,13 +213,9 @@
         invigilator: null,
         editedFields: [],
         fees: false,
-        feesOptions: [
-          {text: 'No', value: false},
-        ],
+        feesOptions: [ {text: 'No', value: false}, ],
         invoice: null,
-        invoiceOptions: [
-          {text: 'Custom', value: 'custom'}
-        ],
+        invoiceOptions: [ {text: 'Custom', value: 'custom'} ],
         labelColor: 'black',
         message: '',
         newEnd: null,

--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -150,12 +150,18 @@ export const ExamReceivedQuestion = Vue.component('exam-received-question', {
         this.captureExamDetail({ key: 'exam_received_date', value: null })
         this.toggleIndividualCaptureTabRadio(e)
       }
+    },
+    modalSetup() {
+      if (this.addExamModal && this.addExamModal.setup) {
+        return this.addExamModal.setup
+      }
+      return ''
     }
   },
   methods: {
     ...mapMutations(['captureExamDetail', 'toggleIndividualCaptureTabRadio']),
     preSetDate() {
-      if (this.addExamModal.setup === 'other') {
+      if (this.modalSetup === 'other' || this.modalSetup === 'pesticide') {
         this.handleInput({
           target: {
             name: 'exam_received_date',
@@ -182,8 +188,8 @@ export const ExamReceivedQuestion = Vue.component('exam-received-question', {
             <span v-if="error" style="color: red">{{ validationObj[q.key].message }}</span>
           </label><br>
           <b-form-radio-group v-model="showRadio"
-                              @input="preSetDate"
-                              :options="addExamModal.setup === 'other' ? otherOptions : options" />
+                              @input="preSetDate()"
+                              :options="['other', 'pesticide'].includes(modalSetup) ? otherOptions : options"/>
         </b-form-group>
         <b-form-group v-else>
           <label>{{ q.text2 }}

--- a/frontend/src/exams/add-exam-form-controller.vue
+++ b/frontend/src/exams/add-exam-form-controller.vue
@@ -264,7 +264,7 @@
     },
     watch: {
       step(newV, oldV) {
-        if (oldV == 2 && newV == 3 && this.addExamModal.setup === 'other') {
+        if (oldV == 2 && newV == 3) {
           setTimeout(()=>{this.validate()}, 200)
         }
       }

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -6,7 +6,7 @@
            hide-footer
            size="md">
     <div v-if="showModal">
-      <span style="font-size: 1.5rem; font-weight:600">Edit Group Exam Booking</span>
+      <span class="q-modal-header">Edit Group Exam Booking</span>
       <b-form>
         <b-form-row>
           <b-col class="mb-2">
@@ -91,22 +91,13 @@
           </b-col>
         </b-form-row>
         <b-form-row align-content="end" align-h="end">
-          <b-col cols="10" v-if="role_code === 'LIAISON' || role_code === 'GA'">
+          <b-col :cols="role_code === 'LIAISON' || role_code === 'GA' ? 10 : '' ">
             <b-form-group>
               <label>Invigilator</label><br>
               <b-select v-model="invigilator_id"
                         name="invigilator_id"
-                        @input.native="checkInput"
-                        :options="invigilatorOptions" />
-            </b-form-group>
-          </b-col>
-          <b-col v-if="role_code !== 'LIAISON' && role_code !== 'GA'">
-            <b-form-group>
-              <label>Invigilator</label><br>
-              <b-select v-model="invigilator_id"
-                        name="invigilator_id"
-                        @input.native="checkInput"
-                        :options="invigilatorOptions" />
+                        @change.native="checkInput"
+                        :options="invigilator_dropdown" />
             </b-form-group>
           </b-col>
           <b-col cols="2" align-self="start" v-if="role_code==='LIAISON' || role_code === 'GA'">
@@ -152,21 +143,11 @@
       }
     },
     computed: {
-      ...mapGetters(['role_code']),
+      ...mapGetters(['role_code', 'invigilator_dropdown']),
       ...mapState({
         showModal: state => state.showEditGroupBookingModal,
         invigilators: state => state.invigilators,
       }),
-      invigilatorOptions() {
-        if (this.invigilators && this.invigilators.length > 0) {
-          let options = this.invigilators.map( inv =>
-            ({text: inv.invigilator_name, value: inv.invigilator_id})
-          )
-          options.push({text: 'unassigned', value: ''})
-          return options
-        }
-        return []
-      },
       modalVisible: {
         get() {
           return this.showModal

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -573,12 +573,13 @@ export const store = new Vuex.Store({
 
   getters: {
     invigilator_dropdown(state) {
-      let invigilators = state.invigilators.map( i =>
-        ({value: i.invigilator_id,
-          text: i.invigilator_name})
-      )
-      invigilators.push({value: 'sbc', text: 'SBC Staff'})
-      invigilators.push({value: null, text: 'unassigned'})
+      let invigilators = [
+        {value: null, text: 'unassigned'},
+        {value: 'sbc', text: 'SBC Staff'}
+      ]
+      state.invigilators.forEach( i => {
+        invigilators.push({ value: i.invigilator_id, text: i.invigilator_name })
+      })
       return invigilators
     },
     


### PR DESCRIPTION
Fixed the edit-group-booking-modal re: issue not allowing submission of invigilator change.  Fixed the hang on the add pesticide exam form where the next button would not switch to enabled on the last step.  fixed issue causing the invigilator dropdown select list (in various places) to be blank when the invigilator is unassigned instead of saying 'unassigned'. several other very minor changes to better support IE11 users.