### PR TITLE
Calendar Room Colors

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -484,13 +484,13 @@ class Bootstrap(Command):
             office_id = office_test.office_id,
             room_name = "Boardroom 1",
             capacity = 25,
-            color = "red"
+            color = "#EFD469"
         )
         room_two = bookings.Room(
             office_id = office_test.office_id,
             room_name = "Turquoise W-135",
             capacity = 25,
-            color = "red"
+            color = "#EFD469"
         )
 
 

--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -457,7 +457,7 @@
           this.$refs.bookingcal.fireMethod('addResource', {
             id: '_offsite',
             title: 'Offsite',
-            eventColor: '#82ff68',
+            eventColor: '#F58B4C',
           })
         }
         if (!bool) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1075,7 +1075,7 @@ export const store = new Vuex.Store({
             resources.push({
               id: '_offsite',
               title: 'Offsite',
-              eventColor: '#82ff68'
+              eventColor: '#F58B4C'
             })
             context.commit('setRooms', resp.data.rooms)
             context.commit('setResources', resources)


### PR DESCRIPTION
Clients indicated that they would like the default colors for onsite and offsite rooms to be changed. Manage.py now includes the default hex value for lighter daisy, as well as modifiying the calendar component and store to make sure offsite rooms now show up as lighter coral.