### PR TITLE
Edit Non-ITA Exam Details Exam Types

### DIFF
--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -361,7 +361,11 @@
             return this.examTypes.filter(type => type.exam_type_name.includes('Group'))
           }
           if (!this.exam.offsite_location) {
-            return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
+            if (this.exam.exam_type.ita_ind == 1) {
+              return this.examTypes.filter(type => type.exam_type_name.includes('Single'))
+            }else {
+              return this.examTypes.filter(type => type.ita_ind == 0)
+            }
           }
         }
         return []


### PR DESCRIPTION
During testing, it was found that the exam type drop down items for non-ita exams were showing up as the ITA exam types. This was fixed by placing a conditional filter on the examType objects returned based on whether or not the ita_ind field is set to 0 or 1.