### PR TITLE
Exam Type Admin Panels

### DIFF
--- a/api/app/admin/__init__.py
+++ b/api/app/admin/__init__.py
@@ -24,4 +24,5 @@ from .service import ServiceModelView
 from .smartboard import SmartBoardModelView
 from .invigilator import InvigilatorModelView
 from .room import RoomModelView
+from .examtype import ExamTypeModelView
 

--- a/api/app/admin/examtype.py
+++ b/api/app/admin/examtype.py
@@ -1,0 +1,74 @@
+'''Copyright 2018 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.'''
+
+from app.models.bookings import ExamType
+from .base import Base
+from flask_login import current_user
+from qsystem import db
+
+
+class ExamTypeConfig(Base):
+    roles_allowed = ['SUPPORT']
+
+    def is_accessible(self):
+        return  current_user.is_authenticated and current_user.role.role_code in self.roles_allowed
+
+    def get_query(self):
+        return self.session.query(self.model)
+
+    create_modal = False
+    edit_modal = False
+    column_list = [
+        'exam_type_name',
+        'exam_color',
+        'number_of_hours',
+        'method_type',
+        'ita_ind',
+        'group_exam_ind'
+    ]
+
+    column_searchable_list = {'exam_type_name'}
+
+    form_create_rules = (
+        'exam_type_name',
+        'exam_color',
+        'number_of_hours',
+        'method_type',
+        'ita_ind',
+        'group_exam_ind'
+    )
+
+    form_edit_rules = (
+        'exam_type_name',
+        'exam_color',
+        'number_of_hours',
+        'method_type',
+        'ita_ind',
+        'group_exam_ind'
+    )
+
+    column_sortable_list = [
+        'exam_type_name',
+        'exam_color',
+        'number_of_hours',
+        'method_type',
+        'ita_ind',
+        'group_exam_ind'
+    ]
+
+    column_default_sort = 'exam_type_name'
+
+
+ExamTypeModelView = ExamTypeConfig(ExamType, db.session)
+

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -75,6 +75,7 @@ flask_admin.add_view(admin.RoleModelView)
 flask_admin.add_view(admin.ServiceModelView)
 flask_admin.add_view(admin.SmartBoardModelView)
 flask_admin.add_view(admin.RoomModelView)
+flask_admin.add_view(admin.ExamTypeModelView)
 flask_admin.add_link(admin.LoginMenuLink(name='Login', category='', url="/api/v1/login/"))
 flask_admin.add_link(admin.LogoutMenuLink(name='Logout', category='', url="/api/v1/logout/"))
 

--- a/frontend/src/buttons-admin.vue
+++ b/frontend/src/buttons-admin.vue
@@ -50,7 +50,8 @@
           {value: 'service', text: 'Provided Services'},
           {value: 'smartboard', text: 'Smartboard Content'},
           {value: 'invigilator', text: 'Invigilators'},
-          {value: 'room', text: 'Rooms'}
+          {value: 'room', text: 'Rooms'},
+          {value: 'examtype', text: 'Exam Types'}
         ],
         optionsGA: [
           {value: 'csr', text: 'CSRs'},


### PR DESCRIPTION
Client testing found that examtype admin panels would be required if new exam types were to be added in the future. This page is only accessable by users with the SUPPORT role, and can create/delete exam types, as well as editing ones that currently exist.