### PR TITLE
Pesticide Exams - Provide Functionality for Designate

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -87,7 +87,8 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
         let exams = this.examTypes.filter( type =>
           !type.exam_type_name.includes('Group') &&
           !type.exam_type_name.includes('Single') &&
-          !type.exam_type_name.includes('Challenger Exam Session')
+          !type.exam_type_name.includes('Challenger Exam Session') &&
+          !type.exam_type_name.includes('Pesticide')
         )
         return exams.sort((a,b) => sorter(a,b))
       }
@@ -145,6 +146,7 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
       <h5 v-if="addExamModal.setup === 'group' ">Add Group Exam</h5>
       <h5 v-if="addExamModal.setup === 'individual' ">Add Individual ITA Exam</h5>
       <h5 v-if="addExamModal.setup === 'other' ">Add Non-ITA Exam</h5>
+      <h5 v-if="addExamModal.setup === 'pesticide' ">Add Pesticide Exam</h5>
       <label>Exam Type</label><br>
         <div @click="clickInput">
           <b-input read-only

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -136,11 +136,6 @@
         tab: 'captureITAExamTabSetup',
         user: 'user',
         module: 'addExamModule',
-        addGroupSteps: state => state.addExamModule.addGroupSteps,
-        addChallengerSteps: state => state.addExamModule.addChallengerSteps,
-        addIndividualSteps: state => state.addExamModule.addIndividualSteps,
-        addOtherSteps: state => state.addExamModule.addOtherSteps,
-        addPesticideSteps: state => state.addExamModule.addPesticideSteps,
         capturtedAddModal: state => state.addExamModule.addExamModal,
       }),
       lastStep() {

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -22,6 +22,9 @@
                 @click="handleClick('group')">Add Group Exam</b-button>
       <b-button class="mr-1 btn-primary"
                 @click="handleClick('other')">Add Other Exam</b-button>
+      <b-button v-if="pesticide_designate===1"
+                class="btn-primary"
+                @click="handleClick('pesticide')">Add Pesticide Exam</b-button>
     </b-form>
     <AddExamModal />
   </div>

--- a/frontend/src/exams/office-drop.vue
+++ b/frontend/src/exams/office-drop.vue
@@ -2,7 +2,7 @@
   <fragment>
     <b-col :cols="columnW">
       <b-table v-show="false"
-               v-if="role_code==='LIAISON'"
+               v-if="role_code==='LIAISON' || pesticide_designate===1"
                :items="offices"
                :fields="{key: 'office_name'}"
                :filter="search"
@@ -63,7 +63,7 @@
       }
     },
     computed: {
-      ...mapGetters([ 'role_code' ]),
+      ...mapGetters([ 'role_code', 'pesticide_designate' ]),
       ...mapState([ 'offices', 'capturedExam' ]),
       office_id() {
         if (this.capturedExam && this.capturedExam.office_id) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -661,7 +661,7 @@ export const store = new Vuex.Store({
     },
     
     getOffices(context, payload=null) {
-      if (context.state.user.role.role_code === 'LIAISON' || payload === 'force') {
+      if (context.state.user.role.role_code === 'LIAISON' || payload === 'force' || context.state.user.pesticide_designate===1) {
         return new Promise((resolve, reject) => {
           Axios(context).get('/offices/').then(resp => {
             context.commit('setOffices', resp.data.offices)


### PR DESCRIPTION
Pesticide exams needed to be broken out of the "Add Non-ITA Exam" button such that a pesticide designate liaison could add these exams on their own. This button that is viewable on the exam inventory page can only be seen by csrs with the field pesticide_designate set to 1. This Add Exam functionality mirrors the functionality of the Non-ITA exam creation, but incorperates a select office chooser as well, and displays a notes field on the summary. This functionality has been tested with the GA role and LIAISON role, both with and without the pesticide_designate column set to 1 to ensure that this functionality is completely on its own.