### PR TITLE
Other Booking Event Title Re-naming

### DIFF
--- a/frontend/src/booking/other-booking-modal.vue
+++ b/frontend/src/booking/other-booking-modal.vue
@@ -19,7 +19,7 @@
         <template v-if="!minimized">
           <b-form>
             <b-form-group>
-              <label>Event Title<span style="color: red">{{ message }}</span></label><br>
+              <label>Scheduling Party<span style="color: red">{{ message }}</span></label><br>
               <b-input :state="state" type="text" v-model="title" />
             </b-form-group>
             <b-form-row>


### PR DESCRIPTION
During client testing, it was found that the client wanted the other booking modal to have the "Event Title" field changed to "Scheduling Party".