### PR TITLE
Implemented Time Tracking Feature

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -233,7 +233,6 @@ class Bootstrap(Command):
             display_dashboard_ind = 0,
             actual_service_ind = 0
         )
-
         category_back_office = theq.Service(
             service_code = "Back Office",
             service_name = "Back Office",
@@ -242,9 +241,18 @@ class Bootstrap(Command):
             display_dashboard_ind = 0,
             actual_service_ind = 0
         )
+        category_exams = theq.Service(
+            service_code = "Exams",
+            service_name = "Exams",
+            service_desc = "Exams",
+            prefix = "E",
+            display_dashboard_ind = 0,
+            actual_service_ind = 0
+        )
         db.session.add(category_msp)
         db.session.add(category_ptax)
         db.session.add(category_back_office)
+        db.session.add(category_exams)
         db.session.commit()
 
         #-- Service values --------------------------------------------------
@@ -320,6 +328,15 @@ class Bootstrap(Command):
             display_dashboard_ind = 1,
             actual_service_ind = 1
         )
+        service_exams = theq.Service(
+            service_code = "Exams - 001",
+            service_name = "Exam Management",
+            service_desc = "ITA or PEST -Checking for expired Exams, contacting ITA or PEST program, mailing back ITA or shredding expired PEST Exams, etc.",
+            parent_id = category_exams.service_id,
+            prefix = "E",
+            display_dashboard_ind = 1,
+            actual_service_ind = 1
+        )
         db.session.add(service_bo1)
         db.session.add(service_bo2)
         db.session.add(service_msp1)
@@ -328,6 +345,7 @@ class Bootstrap(Command):
         db.session.add(service_ptax1)
         db.session.add(service_ptax2)
         db.session.add(service_ptax4)
+        db.session.add(service_exams)
         db.session.commit()
 
         #-- Office values ---------------------------------------------------
@@ -454,6 +472,7 @@ class Bootstrap(Command):
         office_test.services.append(category_back_office)
         office_test.services.append(category_msp)
         office_test.services.append(category_ptax)
+        office_test.services.append(category_exams)
         office_test.services.append(service_bo1)
         office_test.services.append(service_bo2)
         office_test.services.append(service_msp1)
@@ -462,6 +481,7 @@ class Bootstrap(Command):
         office_test.services.append(service_ptax1)
         office_test.services.append(service_ptax2)
         office_test.services.append(service_ptax4)
+        office_test.services.append(service_exams)
 
         office_victoria.services.append(category_back_office)
         office_victoria.services.append(category_msp)

--- a/frontend/src/Socket.vue
+++ b/frontend/src/Socket.vue
@@ -110,7 +110,7 @@ limitations under the License.*/
 
       onUpdateActiveCitizen(citizen) {
         console.log('socket received: "update_active_citizen" ')
-        this.screenIncomingCitizen(citizen)
+        this.screenIncomingCitizen({ citizen, route: this.$route })
       },
 
       onUpdateCustomerList() {

--- a/frontend/src/add-citizen/add-citizen-form.vue
+++ b/frontend/src/add-citizen/add-citizen-form.vue
@@ -16,7 +16,7 @@
     <template v-else>
       <div class="add_citizen_template">
         <div class="add_citizen_padding" style="background: rgb(240, 240, 240);padding-top: 12px;">
-            <Comments />
+            <Comments v-if="!simplifiedModal" />
             <Channel />
             <div style="transform: translateY(18px);">
                 <Filters />
@@ -47,9 +47,20 @@ export default {
     Tables
   },
   computed: {
-    ...mapState(['addModalSetup']),
-    ...mapGetters(['reception'])
-  }
+    ...mapState({addModalSetup: 'addModalSetup', }),
+    ...mapGetters({reception: "reception",}),
+    simplified() {
+      if (this.$route.path !== '/queue') {
+        return true
+      }
+      return false
+    },
+    simplifiedModal() {
+      if (this.simplified && this.addModalSetup !== 'edit_mode') {
+        return true
+      }
+      return false
+    },  }
 }
 
 </script>

--- a/frontend/src/add-citizen/add-citizen.vue
+++ b/frontend/src/add-citizen/add-citizen.vue
@@ -1,65 +1,60 @@
 <template>
-  <b-modal
-    :visible="showAddModal"
-    size="lg"
-    hide-header
-    hide-footer
-    no-close-on-backdrop
-    no-close-on-esc
-    body-class="q-modal-body"
-    class="m-0 p-0"
-    @shown="setupForm()"
-  >
-    <div
-      style="display: flex; flex-direction: row; justify-content: space-between"
-      class="modal_header"
-      v-dragged="onDrag"
-    >
+  <b-modal :visible="showAddModal"
+           :size="simplified ? 'md' : 'lg' "
+           hide-header
+           hide-footer
+           no-close-on-backdrop
+           no-close-on-esc
+           body-class="q-modal-body"
+           class="m-0 p-0"
+           @shown="setupForm()">
+    <div style="display: flex; flex-direction: row; justify-content: space-between"
+         class="modal_header"
+         v-dragged="onDrag">
       <div>
         <h4>{{modalTitle}}</h4>
       </div>
       <div>
-        <button
-          class="btn btn-link"
-          style="margin-left: 20px"
-          @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
+        <button class="btn btn-link"
+                style="margin-left: 20px"
+                @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
       </div>
     </div>
-    <b-alert
-      :show="dismissCountDown"
-      style="h-align: center"
-      variant="danger"
-      @dismissed="dismissCountDown=0"
-      @dismiss-count-down="countDownChanged"
-    >{{this.$store.state.alertMessage}}</b-alert>
+    <b-alert :show="dismissCountDown"
+             style="h-align: center"
+             variant="danger"
+             @dismissed="dismissCountDown=0"
+             @dismiss-count-down="countDownChanged">{{this.$store.state.alertMessage}}</b-alert>
     <div v-if="!minimizeWindow">
       <div v-if="!this.addModalForm.citizen">
-        <div class="loader"></div>
+        <div class="q-loader" />
       </div>
       <div v-else>
-        <AddCitizenForm/>
+        <AddCitizenForm />
         <b-container class="add-buttons add_citizen_padding">
-          <div class="button-row" style="padding-bottom:6px;">
+          <div class="button-row"
+               style="padding-bottom:6px;">
             <div id="select-wrapper">
-              <select id="priority-selection" class="custom-select" v-model="priority_selection">
+              <select id="priority-selection"
+                      v-if="!simplified"
+                      class="custom-select"
+                      v-model="priority_selection">
                 <option value="1">High Priority</option>
                 <option value="2">Default Priority</option>
                 <option value="3">Low Priority</option>
               </select>
             </div>
-            <b-form-checkbox
-              v-model="quickTrans"
-              value="1"
-              unchecked-value="0"
-              v-if="reception"
-              class="quick"
-              style="color:white;margin: 8px;"
-            >
+            <b-form-checkbox v-model="quickTrans"
+                             value="1"
+                             unchecked-value="0"
+                             v-if="reception && !simplified"
+                             class="quick"
+                             style="color:white;margin: 8px;">
               <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
             </b-form-checkbox>
           </div>
           <div class="button-row">
-            <Buttons/>
+            <Buttons />
           </div>
         </b-container>
       </div>
@@ -68,111 +63,113 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapMutations, mapActions } from "vuex";
-import Buttons from "./form-components/buttons";
-import AddCitizenForm from "./add-citizen-form";
+import { mapState, mapGetters, mapMutations, mapActions } from "vuex"
+import Buttons from "./form-components/buttons"
+import AddCitizenForm from "./add-citizen-form"
 
 export default {
   name: "AddCitizen",
-
   components: {
     AddCitizenForm,
     Buttons
   },
-
   mounted() {
     this.$root.$on("showAddMessage", () => {
-      this.showAlert();
-    });
+      this.showAlert()
+    })
   },
-
   data() {
     return {
       dismissSecs: 5,
       dismissCountDown: 0,
       minimizeWindow: false
-    };
+    }
   },
-
   computed: {
-    ...mapState([
-      "addCitizenModal",
-      "addModalForm",
-      "showAddModal",
-      "addModalSetup",
-      "serviceModalForm"
-    ]),
-    ...mapGetters(["form_data", "reception"]),
-
+    ...mapState({
+      addCitizenModal: 'addCitizenModal',
+      addModalForm: 'addModalForm',
+      showAddModal: 'showAddModal',
+      addModalSetup: 'addModalSetup',
+      serviceModalForm: 'serviceModalForm',
+    }),
+    ...mapGetters({form_data: "form_data", reception: "reception",}),
+    simplified() {
+      if (this.$route.path !== '/queue') {
+        return true
+      }
+      return false
+    },
     modalTitle() {
       if (this.addModalSetup === "edit_mode") {
-        return "Edit Service";
-      } else {
-        return "Add Citizen";
+        return "Edit Service"
       }
+      if (this.simplified) {
+        return 'Begin Tracking'
+      }
+      return "Add Citizen"
     },
-
     quickTrans: {
       get() {
-        return this.form_data.quick;
+        return this.form_data.quick
       },
       set(value) {
-        this.updateAddModalForm({ type: "quick", value });
+        this.updateAddModalForm({ type: "quick", value })
       }
     },
-
     priority_selection: {
       get() {
-        return this.form_data.priority;
+        return this.form_data.priority
       },
       set(value) {
-        this.updateAddModalForm({ type: "priority", value });
+        this.updateAddModalForm({ type: "priority", value })
       }
     }
   },
-
   methods: {
     ...mapActions(["cancelAddCitizensModal"]),
     ...mapMutations(["updateAddModalForm", "setDefaultChannel"]),
-
     countDownChanged(dismissCountDown) {
-      this.dismissCountDown = dismissCountDown;
+      this.dismissCountDown = dismissCountDown
     },
     setupForm() {
       let setup = this.addModalSetup;
+      if (this.simplified) {
+        this.$root.$emit("focusfilter")
+        return
+      }
       if (setup === "add_mode" || setup === "edit_mode") {
-        this.$root.$emit("focusfilter");
+        this.$root.$emit("focusfilter")
       } else {
         if (!this.reception) {
-          this.$root.$emit("focusfilter");
+          this.$root.$emit("focusfilter")
         } else if (this.reception) {
-          this.$root.$emit("focuscomments");
+          this.$root.$emit("focuscomments")
         }
       }
     },
-    showAlert() {
-      this.dismissCountDown = this.dismissSecs;
+    Alert() {
+      this.dismissCountDown = this.dismissSecs
     },
     toggleMinimize() {
-      this.minimizeWindow = !this.minimizeWindow;
+      this.minimizeWindow = !this.minimizeWindow
     },
     onDrag({ el, deltaX, deltaY, offsetX, offsetY, clientX, clientY, first, last }) {
       if (first) {
-        this.dragged = true;
-        return;
+        this.dragged = true
+        return
       }
       if (last) {
-        this.dragged = false;
-        return;
+        this.dragged = false
+        return
       }
-      this.left = (this.left || 0) + deltaX;
-      this.top = (this.top || 0) + deltaY;
-
+      this.left = (this.left || 0) + deltaX
+      this.top = (this.top || 0) + deltaY
       var add_modal = document.getElementsByClassName('modal-content')[0]
       add_modal.style.transform = "translate("+this.left+"px,"+this.top+"px)"
     }
   }
-};
+}
 </script>
 
 <style>
@@ -193,31 +190,5 @@ export default {
   background: #504e4f;
   display: flex;
   flex-direction: row-reverse;
-}
-
-.loader {
-  position: relative;
-  text-align: center;
-  margin: 15px auto 35px auto;
-  z-index: 9999;
-  display: block;
-  width: 80px;
-  height: 80px;
-  border: 10px solid rgba(0, 0, 0, 0.3);
-  border-radius: 50%;
-  border-top-color: #000;
-  animation: spin 1s ease-in-out infinite;
-  -webkit-animation: spin 1s ease-in-out infinite;
-}
-@keyframes spin {
-  to {
-    -webkit-transform: rotate(360deg);
-  }
-}
-
-@-webkit-keyframes spin {
-  to {
-    -webkit-transform: rotate(360deg);
-  }
 }
 </style>

--- a/frontend/src/add-citizen/form-components/filters.vue
+++ b/frontend/src/add-citizen/form-components/filters.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-form-row no-gutters>
-      <b-col cols="7">
+      <b-col :cols="simplified ? 12 : 7">
           <input ref="filterref"
                  style="height: 38px; font-size: .8rem;"
                  class="form-control"
@@ -9,7 +9,7 @@
                  placeholder="Type service here"
                  ></input>
       </b-col>
-      <b-col>
+      <b-col v-if="!simplified">
           <b-select id="add_citizen_catagories_select"
                     style="height: 38px; font-size: .8rem;"
                     :options="categories_options"
@@ -36,12 +36,27 @@
     },
 
     computed: {
-      ...mapGetters(['categories_options', 'form_data']),
-      ...mapState({
-                    suspendFilter: state => state.addModalForm.suspendFilter,
-                    selectedItem: state => state.addModalForm.selectedItem
+      ...mapGetters({
+        categories_options: 'categories_options',
+        form_data: 'form_data',
       }),
-
+      ...mapState({
+        addModalSetup: 'addModalSetup',
+        suspendFilter: state => state.addModalForm.suspendFilter,
+        selectedItem: state => state.addModalForm.selectedItem,
+      }),
+      simplified() {
+        if (this.$route.path !== '/queue') {
+          return true
+        }
+        return false
+      },
+      simplifiedModal() {
+        if (this.simplified && this.addModalSetup !== 'edit_mode') {
+          return true
+        }
+        return false
+      },
       search: {
         get() {
           if (this.suspendFilter) {

--- a/frontend/src/add-citizen/form-components/tables.vue
+++ b/frontend/src/add-citizen/form-components/tables.vue
@@ -10,7 +10,7 @@
     <b-form-row no-gutters class="m-0 add_citizen_table_header"
                        >
       <b-col class="m-0 p-0">&nbsp&nbspService</b-col>
-      <b-col class="m-0 p-0">Category</b-col>
+      <b-col class="m-0 p-0" v-if="!simplifiedModal">Category</b-col>
     </b-form-row>
     <b-form-row no-gutters>
       <b-col>
@@ -24,6 +24,7 @@
                    :fields="fields"
                    sort-by="parrent.service_name"
                    :filter="filter"
+                   :tbody-tr-class="addcitizen-tr"
                    :small="t"
                    :bordered="f"
                    :striped="f"
@@ -57,26 +58,49 @@
 
   export default {
     name: 'Tables',
-
     data() {
       return {
         f:false,
         t:true,
-        fields: [
-          { key: 'service_name', label: 'Service', sortable: false, thClass: 'd-none' },
-          { key: 'parent.service_name', label: 'Category', sortable: false, thClass: 'd-none' },
-          { key: 'service_desc', label: 'Description', sortable: false, thClass: 'd-none', tdClass: 'd-none' }
-        ]
       }
     },
-
     computed: {
-      ...mapState(['addCitizenModal']),
-      ...mapGetters(['form_data', 'filtered_services']),
+      ...mapState({
+        addModalSetup: 'addModalSetup',
+        addCitizenModal: 'addCitizenModal',
 
+      }),
+      ...mapGetters({form_data: 'form_data', filtered_services: 'filtered_services',}),
+      simplified() {
+        if (this.$route.path !== '/queue') {
+          return true
+        }
+        return false
+      },
+      simplifiedModal() {
+        if (this.simplified && this.addModalSetup !== 'edit_mode') {
+          return true
+        }
+        return false
+      },
+      fields() {
+        if (!this.simplifiedModal) {
+          return [
+            { key: 'service_name', label: 'Service', sortable: false, thClass: 'd-none', tdClass: 'addcit-td',},
+            { key: 'parent.service_name', label: 'Category', sortable: false, thClass: 'd-none', tdClass: 'addcit-td',},
+            { key: 'service_desc', label: 'Description', sortable: false, thClass: 'd-none', tdClass: 'd-none',}
+          ]
+        }
+        return [
+          { key: 'service_name', label: 'Service', sortable: false, thClass: 'd-none', tdClass: 'addcit-td',},
+        ]
+      },
       filter(value) {
-        return this.form_data.search
-      }
+        if (!this.simplified) {
+          return this.form_data.search
+        }
+        return 'Exams'
+      },
     },
 
     methods: {
@@ -105,5 +129,8 @@
     text-align: center;
     font-size: 17px;
     text-shadow: 0px 0px 2px #a5a5a5;
+}
+.addcit-td {
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/assets/css/q.css
+++ b/frontend/src/assets/css/q.css
@@ -114,3 +114,27 @@
   margin-top: 0px;
   margin-bottom: 15px;
 }
+.q-loader {
+  position: relative;
+  text-align: center;
+  margin: 15px auto 35px auto;
+  z-index: 9999;
+  display: block;
+  width: 80px;
+  height: 80px;
+  border: 10px solid rgba(0, 0, 0, .3);
+  border-radius: 50%;
+  border-top-color: #000;
+  animation: spin 1s ease-in-out infinite;
+  -webkit-animation: spin 1s ease-in-out infinite;
+}
+@keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}

--- a/frontend/src/exams/exams.vue
+++ b/frontend/src/exams/exams.vue
@@ -10,13 +10,13 @@
     </div>
   </div>
   <div v-else>
-    <div class="loader"></div>
+    <div class="q-loader"></div>
   </div>
 
 </template>
 
 <script>
-  import { mapGetters, mapState } from 'vuex'
+  import { mapMutations, mapGetters, mapState } from 'vuex'
   import ExamInventoryTable from './exam-inventory-table'
 
   export default {
@@ -26,13 +26,17 @@
       this.$store.dispatch('getOffices')
     },
     computed: {
-      ...mapState([
-        'user',
-      ]),
-      ...mapGetters([
-        'showExams',
-      ])
+      ...mapState({
+        serviceBegun: 'serviceBegun',
+        showServiceModal: 'showServiceModal',
+        serviceModalPath: 'serviceModalPath',
+        user: 'user',
+      }),
+      ...mapGetters(['showExams', ]),
     },
+    methods: {
+      ...mapMutations(['toggleServiceModal', ]),
+    }
   }
 </script>
 
@@ -49,32 +53,5 @@
   }
   div.center {
     text-align: center;
-  }
-
-  .loader {
-    position: relative;
-    text-align: center;
-    margin: 15px auto 35px auto;
-    z-index: 9999;
-    display: block;
-    width: 80px;
-    height: 80px;
-    border: 10px solid rgba(0, 0, 0, .3);
-    border-radius: 50%;
-    border-top-color: #000;
-    animation: spin 1s ease-in-out infinite;
-    -webkit-animation: spin 1s ease-in-out infinite;
-  }
-
-  @keyframes spin {
-    to {
-      -webkit-transform: rotate(360deg);
-    }
-  }
-
-  @-webkit-keyframes spin {
-    to {
-      -webkit-transform: rotate(360deg);
-    }
   }
 </style>

--- a/frontend/src/layout/nav.vue
+++ b/frontend/src/layout/nav.vue
@@ -18,8 +18,18 @@
   <div style="position: relative">
     <div class="dash-button-flex-button-container pb-0 mb-3">
       <!-- SLOT FOR EACH VIEW'S BUTTON CONTROLS-->
-      <router-view name="buttons"/>
-      <div v-if="calendarSetup"
+      <div v-if="this.$route.path === '/booking' || this.$route.path === '/exams' ">
+        <b-button :variant="showIcon ? 'warning' : 'primary'"
+                  class="mr-3"
+                  @click="clickIcon">
+          <font-awesome-icon icon="stopwatch"
+                             style="font-size: 1.0rem;color: white;"
+                             class="p0" />
+        </b-button>
+      </div>
+      <router-view name="buttons"></router-view>
+
+      <div v-if="calendarSetup && this.$route.path === '/booking'"
            style="flex-grow: 8"
            class="q-inline-title">{{ calendarSetup.title }}</div>
     <div />
@@ -64,27 +74,46 @@
     <div style="position: relative; min-height: 400px;">
       <router-view />
     </div>
+    <AddCitizen />
+    <ServeCitizen v-if="showServiceModal"/>
   </div>
 </template>
 
 <script>
   import { mapState, mapActions, mapMutations, mapGetters } from 'vuex'
+  import ServeCitizen from '../serve-citizen/serve-citizen'
+  import AddCitizen from '../add-citizen/add-citizen'
 
   export default {
     name: 'Nav',
+    components: { AddCitizen, ServeCitizen },
     computed: {
       ...mapGetters([
         'showExams',
         'showAppointments'
       ]),
       ...mapState([
+        'showServiceModal',
         'calendarSetup',
         'rescheduling',
         'scheduling',
+        'serviceModalForm',
+        'serviceBegun',
         'showGAScreenModal',
         'showServiceModal',
+        'showAddModal',
         'user',
       ]),
+      showIcon() {
+        if (this.$route.path !== '/queue' &&
+            !this.showServiceModal &&
+            !this.showAddModal &&
+            this.serviceModalForm &&
+            this.serviceModalForm.citizen_id) {
+          return true
+        }
+        return false
+      },
       isGAorCSR() {
         if (this.user && this.user.role) {
           let { role_code } = this.user.role
@@ -112,11 +141,18 @@
       },
     },
     methods: {
-      ...mapActions(['clickGAScreen']),
-      ...mapMutations(['toggleFeedbackModal']),
+      ...mapActions(['clickGAScreen', 'clickAddCitizen']),
+      ...mapMutations(['toggleFeedbackModal', 'toggleServiceModal']),
       clickFeedback() {
         this.toggleFeedbackModal(true)
       },
+      clickIcon() {
+        if (this.showIcon) {
+          this.toggleServiceModal(true)
+          return
+        }
+        this.clickAddCitizen()
+      }
     }
   }
 </script>
@@ -140,5 +176,11 @@
   }
   .gaScreenUnchecked {
     padding-left: 1.5em
+  }
+  .tracking-icon {
+    font-size: 2.75rem;
+    border-radius: 5px;
+    box-shadow: -4px 4px 4px 0px grey;
+    cursor: pointer;
   }
 </style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -32,6 +32,8 @@ import {
   faCalendarTimes,
 } from '@fortawesome/free-regular-svg-icons'
 import {
+  faWindowMaximize,
+  faWindowRestore,
   faAngleLeft,
   faAngleRight,
   faBars,
@@ -50,6 +52,7 @@ import {
   faMinus,
   faPlus,
   faSort,
+  faStopwatch,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import VDragged from 'v-dragged'
@@ -78,6 +81,9 @@ library.add(
   faMinus,
   faPlus,
   faSort,
+  faStopwatch,
+  faWindowMaximize,
+  faWindowRestore,
 )
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 Vue.use(BootstrapVue)

--- a/frontend/src/serve-citizen/dash-buttons.vue
+++ b/frontend/src/serve-citizen/dash-buttons.vue
@@ -68,7 +68,7 @@
     methods: {
       ...mapMutations([
         'setMainAlert',
-        'toggleFeedbackModal'
+        'toggleFeedbackModal',
       ]),
       ...mapActions([
         'clickInvite',

--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -8,7 +8,8 @@
                 variant="warning">{{this.serveModalAlert}}</b-alert>
       <div class="modal_header" v-dragged="onDrag">
         <div>
-          <h4 style="font-weight:900; color:#6e6e6e">Serve Citizen</h4>
+          <h4 style="font-weight:900; color:#6e6e6e">
+            {{ simplifiedModal ? 'Exams Time Tracking' : 'Servce Citizen' }}</h4>
         </div>
         <div>
           <button
@@ -20,28 +21,29 @@
                     @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
         </div>
       </div>
-      <b-container id="serve-citizen-modal-top" fluid v-if="!minimizeWindow">
-        <b-row no-gutters class="p-2">
-          <b-col col cols="4">
-            <div><h6>Ticket #: <strong>{{citizen.ticket_number}}</strong></h6></div>
-            <div><h6>Channel: <strong>{{channel.channel_name}}</strong></h6></div>
-            <div><h6>Created At: <strong>{{formatTime(citizen.start_time)}}</strong></h6></div>
-          </b-col>
-          <b-col cols="auto" class="ml-3 mr-2">
-            <h6>Comments:</h6>
-          </b-col>
-          <b-col col cols="*" style="text-align: left" class="pr-2">
-            <div>
-              <b-textarea id="serve_comment_textarea"
-                          v-model="comments"
-                          :rows="4"
-                          size="sm" />
-            </div>
-          </b-col>
-        </b-row>
-      </b-container>
-      <b-container id="serve-top-buttons-container" v-if="!minimizeWindow">
-        <div>
+      <template v-if="!simplifiedModal">
+        <b-container id="serve-citizen-modal-top" fluid v-if="!minimizeWindow">
+          <b-row no-gutters class="p-2">
+            <b-col col cols="4">
+              <div><h6>Ticket #: <strong>{{citizen.ticket_number}}</strong></h6></div>
+              <div><h6>Channel: <strong>{{channel.channel_name}}</strong></h6></div>
+              <div><h6>Created At: <strong>{{formatTime(citizen.start_time)}}</strong></h6></div>
+            </b-col>
+            <b-col cols="auto" class="ml-3 mr-2">
+              <h6>Comments:</h6>
+            </b-col>
+            <b-col col cols="*" style="text-align: left" class="pr-2">
+              <div>
+                <b-textarea id="serve_comment_textarea"
+                            v-model="comments"
+                            :rows="4"
+                            size="sm" />
+              </div>
+            </b-col>
+          </b-row>
+        </b-container>
+        <b-container id="serve-top-buttons-container" v-if="!minimizeWindow">
+          <div>
             <b-button @click="clickServiceBeginService"
                     v-if="reception"
                     :disabled="serviceBegun===true || performingAction"
@@ -53,63 +55,96 @@
                     :disabled="performingAction"
                     class="btn serve-btn"
                     id="serve-citizen-return-to-queue-button">Return to Queue</b-button>
-        </div>
-        <div>
+          </div>
+          <div>
             <b-button @click="clickCitizenLeft"
                     :disabled="performingAction"
                     class="btn-danger serve-btn"
                     v-if="reception"
                     id="serve-citizen-citizen-left-button">Citizen Left</b-button>
-        </div>
-    </b-container>
-      <ServeCitizenTable v-if="!minimizeWindow"/>
-      <b-container fluid
-                   id="serve-light-inner-container"
-                   class="pt-3 pb-2"
-                    v-if="!minimizeWindow">
-        <b-row no-gutters>
-          <b-col cols="7" />
-          <b-col cols="auto" style="align: right">
-            <b-form-checkbox v-model="quick" value="1" unchecked-value="0" v-if="reception"
-                            class="quick-checkbox" style="color:white;margin-right: 8px;">
-                <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
-                <span class="quick-span" v-if="quick"></span> <!-- For puppeteer testing to see if quick is selected -->
-            </b-form-checkbox>
-            <select id="priority-selection" class="custom-select" v-model="priority_selection" style="margin-right:8px;">
-                <option value=1>High Priority</option>
-                <option value=2>Default Priority</option>
-                <option value=3>Low Priority</option>
-            </select>
-            <b-button class="btn-primary serve-btn"
-                      @click="clickAddService"
-                      :disabled="serviceBegun===false || performingAction"
-                      >Add Next Service</b-button>
-          </b-col>
-          <b-col cols="2" />
-        </b-row>
-      </b-container>
-      <div v-if="!minimizeWindow">
-        <b-container fluid
-                     id="serve-citizen-modal-footer">
-                <div style="display:flex; flex-direction:column; margin-left:10px;">
-                    <b-form-checkbox v-model="accurate_time_ind"
-                                                    v-if="serviceBegun===true"
-                                                    value="0"
-                                                    style="color:white; margin:0 0 8px;"
-                                                    unchecked-value="1">
-                                    <span  style="font: 400 16px Myriad-Pro;">Inaccurate Time</span>
-                                    </b-form-checkbox>
-                    <b-button @click="clickServiceFinish"
-                            :disabled="serviceBegun===false || performingAction"
-                            class="btn-success serve-btn"
-                            id="serve-citizen-finish-button">Finish</b-button>
-                </div>
-              <b-button @click="clickHold"
-                        :disabled="serviceBegun===false || performingAction"
-                        class="btn-warning serve-btn"
-                        id="serve-citizen-place-on-hold-button">Place on Hold</b-button>
+          </div>
         </b-container>
-      </div>
+      </template>
+      <ServeCitizenTable v-if="!minimizeWindow"/>
+      <template v-if="!simplifiedModal && !minimizeWindow">
+        <b-container fluid
+                     id="serve-light-inner-container"
+                     class="pt-3 pb-2">
+          <b-row no-gutters>
+            <b-col cols="7" />
+            <b-col cols="auto"
+                   style="align: right">
+              <b-form-checkbox v-model="quick"
+                               value="1"
+                               unchecked-value="0"
+                               v-if="reception"
+                               class="quick-checkbox"
+                               style="color:white; margin-right: 8px;">
+                  <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
+                  <span class="quick-span" v-if="quick"></span> <!-- For puppeteer testing to see if quick is selected -->
+              </b-form-checkbox>
+              <select id="priority-selection"
+                      class="custom-select"
+                      v-model="priority_selection"
+                      style="margin-right:8px;">
+                  <option value=1>High Priority</option>
+                  <option value=2>Default Priority</option>
+                  <option value=3>Low Priority</option>
+              </select>
+              <b-button class="btn-primary serve-btn"
+                        @click="clickAddService"
+                        :disabled="serviceBegun===false || performingAction">Add Next Service</b-button>
+            </b-col>
+            <b-col cols="2" />
+          </b-row>
+        </b-container>
+        <div v-if="!minimizeWindow">
+          <b-container fluid
+                       id="serve-citizen-modal-footer">
+                  <div style="display:flex; flex-direction:column; margin-left:10px;">
+                      <b-form-checkbox v-model="accurate_time_ind"
+                                                      v-if="serviceBegun===true"
+                                                      value="0"
+                                                      style="color:white; margin:0 0 8px;"
+                                                      unchecked-value="1">
+                                      <span  style="font: 400 16px Myriad-Pro;">Inaccurate Time</span>
+                                      </b-form-checkbox>
+                      <b-button @click="clickServiceFinish"
+                              :disabled="serviceBegun===false || performingAction"
+                              class="btn-success serve-btn"
+                              id="serve-citizen-finish-button">Finish</b-button>
+                  </div>
+                <b-button @click="clickHold"
+                          :disabled="serviceBegun===false || performingAction"
+                          class="btn-warning serve-btn"
+                          id="serve-citizen-place-on-hold-button">Place on Hold</b-button>
+          </b-container>
+        </div>
+      </template>
+      <template v-if="simplifiedModal && !minimizeWindow">
+        <b-container class="serve-citizen-modal-footer" fluid>
+          <b-row no-gutters class="w-100" align-h="end">
+            <b-col cols="auto">
+              <b-button class="btn-primary serve-btn"
+                        @click="clickAddService">Add Next Service</b-button>
+            </b-col>
+          </b-row>
+          <b-row no-gutters
+                 class="mt-3"
+                 align-h="end">
+            <b-col cols="auto">
+              <b-button @click="clickSimplifiedFinish"
+                        style="width: 100px;"
+                         class="btn-warning serve-btn"
+                         id="serve-citizen-finish-button">Finish</b-button>
+              <b-button @click="clickContinue"
+                        style="width: 100px;"
+                        class="btn-success serve-btn ml-2"
+                        id="serve-citizen-finish-button">Continue</b-button>
+            </b-col>
+          </b-row>
+        </b-container>
+      </template>
     </div>
   </div>
 </template>
@@ -140,9 +175,8 @@ export default {
   updated() {
     if (!this.citizen && this.citizen.ticket_number === "") {
       console.log("Screen All Citizens")
-      this.screenAllCitizens()
+      this.screenAllCitizens(this.$route)
     }
-
     setTimeout( () => {
       if (!this.citizen && this.citizen.ticket_number === "") {
         this.setServeModalAlert("An error occurred loading citizen, please try refreshing the page.")
@@ -157,7 +191,18 @@ export default {
       'serviceModalForm',
       'serveModalAlert'
     ]),
-    ...mapGetters(['invited_citizen', 'active_service', 'invited_service_reqs', 'reception']),
+    ...mapGetters({
+      invited_citizen: 'invited_citizen',
+      active_service: 'active_service',
+      invited_service_reqs: 'invited_service_reqs',
+      reception: 'reception',
+    }),
+    simplifiedModal() {
+      if (this.$route.path !== '/queue') {
+        return true
+      }
+      return false
+    },
     citizen() {
       if (!this.invited_citizen) {
         return {ticket_number: ''}
@@ -217,10 +262,18 @@ export default {
       'screenAllCitizens',
       'setServeModalAlert'
     ]),
-    ...mapMutations(['editServiceModalForm', 'toggleFeedbackModal']),
+    ...mapMutations(['editServiceModalForm', 'toggleFeedbackModal', 'toggleServiceModal', 'toggleExamsTrackingIP']),
     formatTime(data) {
       let date = new Date(data)
       return date.toLocaleTimeString()
+    },
+    clickSimplifiedFinish() {
+      this.toggleExamsTrackingIP(false)
+      this.clickServiceFinish()
+    },
+    clickContinue() {
+      this.toggleExamsTrackingIP(true)
+      this.toggleServiceModal(false)
     },
     toggleFeedback() {
       this.toggleFeedbackModal(true)
@@ -308,6 +361,11 @@ export default {
     background: #504E4F;
     display: flex;
     flex-direction: row-reverse;
+}
+.serve-citizen-modal-footer {
+  background: #504E4F;
+  padding-top: 30px;
+  padding-bottom: 25px;
 }
 #serve-citizen-modal-footer {
     background: #504E4F;


### PR DESCRIPTION
Applied router navigation guard to dash.vue so that when navigating away from theQ to either Exam Management or Room Booking, the AddCitizenModal appears (simplified version) pre-filtered to "Exams" catagory of service_reqs.  User can select a catagory and proceed, and can finish time tracking by either clicking the icon which appears or returning to the Q.