### PR TITLE
Designate Getter Re-Factor

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -527,7 +527,7 @@ export const SelectOffice = Vue.component('select-office', {
     return {}
   },
   computed: {
-    ...mapGetters(['role_code', 'pesticide_designate', ]),
+    ...mapGetters(['role_code' ]),
     ...mapState(['offices', 'user', 'addExamModal']),
     office_number() {
       return this.addExamModal.office_number

--- a/frontend/src/exams/add-exam-form-confirm.vue
+++ b/frontend/src/exams/add-exam-form-confirm.vue
@@ -24,7 +24,7 @@
         </template>
       </b-col>
     </b-row>
-    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group' || pesticide_designate===1">
+    <b-row no-gutters align-h="between" align-v="end" v-if="setup === 'group' || is_pesticide_designate">
       <b-col cols="1" />
       <b-col cols="3">
         <span class="confirm-header">Office</span>
@@ -219,7 +219,7 @@
         addExamModal: state => state.addExamModal,
         offices: state => state.offices,
       }),
-      ...mapGetters(['exam_object', 'pesticide_designate', ]),
+      ...mapGetters(['exam_object', 'is_pesticide_designate', ]),
       officeName() {
         if (this.addExamModal.setup === 'group' || this.addExamModal.setup === 'pesticide' && this.exam.office_id ) {
           let office = this.offices.find(o => o.office_id == this.exam.office_id)

--- a/frontend/src/exams/add-exam-form-controller.vue
+++ b/frontend/src/exams/add-exam-form-controller.vue
@@ -36,7 +36,7 @@
                       :handleInput="handleInput"
                       :exam="exam" />
       <SelectOffice v-if="q.kind==='office'"
-                    v-show="role_code === 'LIAISON' || pesticide_designate === 1"
+                    v-show="role_code === 'LIAISON' || is_pesticide_designate"
                     :error="error"
                     :q="q"
                     :validationObj="validationObj"
@@ -125,7 +125,7 @@
         steps: 'add_modal_steps',
         exam_object: 'exam_object',
         role_code: 'role_code',
-        pesticide_designate: 'pesticide_designate',
+        is_pesticide_designate: 'is_pesticide_designate',
       }),
       ...mapState({
         exam: state => state.capturedExam,

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -1,5 +1,5 @@
 <template v-if="showExams">
-  <div class="q-w100-flex-fe pr-3" v-if="financial_designate === 1">
+  <div class="q-w100-flex-fe pr-3" v-if="is_financial_designate">
     <b-button class="btn-primary mr-3"
               @click="clickGenFinReport">Generate Financial Report</b-button>
     <FinancialReportModal />
@@ -40,10 +40,7 @@
     components: { AddExamModal, FinancialReportModal },
     computed: {
       ...mapState(['addNonITA', 'showGenFinReportModal', 'user', ]),
-      ...mapGetters([ 'showExams', 'role_code', 'is_pesticide_designate', 'financial_designate', ]),
-    },
-    created() {
-      console.log(this.financial_designate)
+      ...mapGetters([ 'showExams', 'role_code', 'is_pesticide_designate', 'is_financial_designate', ]),
     },
     methods: {
       ...mapActions(['actionRestoreAll']),

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -22,7 +22,7 @@
                 @click="handleClick('group')">Add Group Exam</b-button>
       <b-button class="mr-1 btn-primary"
                 @click="handleClick('other')">Add Other Exam</b-button>
-      <b-button v-if="pesticide_designate===1"
+      <b-button v-if="is_pesticide_designate"
                 class="btn-primary"
                 @click="handleClick('pesticide')">Add Pesticide Exam</b-button>
     </b-form>
@@ -40,7 +40,7 @@
     components: { AddExamModal, FinancialReportModal },
     computed: {
       ...mapState(['addNonITA', 'showGenFinReportModal', 'user', ]),
-      ...mapGetters([ 'showExams', 'role_code', 'pesticide_designate', 'financial_designate', ]),
+      ...mapGetters([ 'showExams', 'role_code', 'is_pesticide_designate', 'financial_designate', ]),
     },
     created() {
       console.log(this.financial_designate)

--- a/frontend/src/exams/office-drop.vue
+++ b/frontend/src/exams/office-drop.vue
@@ -2,7 +2,7 @@
   <fragment>
     <b-col :cols="columnW">
       <b-table v-show="false"
-               v-if="role_code==='LIAISON' || pesticide_designate===1"
+               v-if="role_code==='LIAISON' || is_pesticide_designate"
                :items="offices"
                :fields="{key: 'office_name'}"
                :filter="search"
@@ -63,7 +63,7 @@
       }
     },
     computed: {
-      ...mapGetters([ 'role_code', 'pesticide_designate' ]),
+      ...mapGetters([ 'role_code', 'is_pesticide_designate' ]),
       ...mapState([ 'offices', 'capturedExam' ]),
       office_id() {
         if (this.capturedExam && this.capturedExam.office_id) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -282,11 +282,15 @@ export const store = new Vuex.Store({
       return false
     },
 
-    financial_designate(state) {
+    is_financial_designate(state) {
       if (state.user && state.user.role && state.user.role.role_code) {
-        return state.user.finance_designate
+        if (state.user.finance_designate == 1){
+          return true
+        }else{
+          return false
+        }
       }
-      return ''
+      return false
     },
     
     reception(state) {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -271,11 +271,15 @@ export const store = new Vuex.Store({
       return ''
     },
 
-    pesticide_designate(state) {
+    is_pesticide_designate(state) {
       if (state.user && state.user.role && state.user.role.role_code) {
-        return state.user.pesticide_designate
+        if (state.user.pesticide_designate == 1) {
+          return true
+        }else {
+          return false
+        }
       }
-      return ''
+      return false
     },
 
     financial_designate(state) {


### PR DESCRIPTION
During review/testing of previous PRs, it was found that the pesticide designate getter should return a boolean value, and be renamed to include an 'is'. The getter is now named 'is_pesticide_designate' and returns a true or false value. This refactor also includes modifying all files that used this getter previously, modifiying the name, and how it was used. This re-factor has been full tested to ensure that functionality has not been lost.