### PR TITLE
SQL Script Clean-up

### DIFF
--- a/api/migrations/sql_scripts/offices.sql
+++ b/api/migrations/sql_scripts/offices.sql
@@ -1,85 +1,85 @@
 use qsystem;
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (4, 'Smithers', 2, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (4, 'Smithers', 2, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (5, 'Nelson', 3, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (5, 'Nelson', 3, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (6, 'Castlegar', 4, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (6, 'Castlegar', 4, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (7, 'Merrit', 5, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (7, 'Merrit', 5, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (8, 'Kamloops', 6, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (8, 'Kamloops', 6, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (9, 'Keremeos', 7, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (9, 'Keremeos', 7, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (10, 'Cranbrook', 8, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (10, 'Cranbrook', 8, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (11, 'Dees Lake', 9, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (11, 'Dees Lake', 9, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (12, 'Mission', 10, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (12, 'Mission', 10, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (14, 'Prince George', 14, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (14, 'Prince George', 14, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (15, 'Nakusp', 15, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (15, 'Nakusp', 15, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (16, 'Langley', 16, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (16, 'Langley', 16, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (17, 'Revelstoke', 17, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (17, 'Revelstoke', 17, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (18, 'Vernon', 18, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (18, 'Vernon', 18, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (19, 'Golden', 19, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (19, 'Golden', 19, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (20, 'Lilooet', 19, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (20, 'Lilooet', 19, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (21, 'Prince Rupert', 21, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (21, 'Prince Rupert', 21, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (22, 'Nanaimo', 22, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (22, 'Nanaimo', 22, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (23, 'Ladysmith', 23, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (23, 'Ladysmith', 23, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (24, 'Courtney', 24, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (24, 'Courtney', 24, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (25, 'Hope', 25, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (25, 'Hope', 25, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (26, 'Abbottsford', 26, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (26, 'Abbottsford', 26, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (27, 'Chilliwack', 27, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (27, 'Chilliwack', 27, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (28, 'Osoyoos', 28, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (28, 'Osoyoos', 28, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (29, 'Coquitlam', 29, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (29, 'Coquitlam', 29, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (30, 'Salmon Arm', 30, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (30, 'Salmon Arm', 30, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (31, 'Creston', 31, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (31, 'Creston', 31, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (32, 'Salmo', 32, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (32, 'Salmo', 32, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (33, 'Kitimat', 33, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (33, 'Kitimat', 33, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (34, 'Port Hardy', 34, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (34, 'Port Hardy', 34, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (35, 'Dawson Creek', 35, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (35, 'Dawson Creek', 35, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (36, 'Kelowna', 36, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (36, 'Kelowna', 36, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (37, 'Surrey', 37, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (37, 'Surrey', 37, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (38, 'Terrace', 38, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (38, 'Terrace', 38, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (39, 'Penticton', 39, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (39, 'Penticton', 39, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (40, 'Powell River', 40, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (40, 'Powell River', 40, 2, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (41, 'Squamish', 41, 3, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (41, 'Squamish', 41, 3, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (43, 'Trail', 43, 1, null, 0);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (43, 'Trail', 43, 1, null, 0, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (44, 'Lumby', 44, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (44, 'Lumby', 44, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (45, 'Williams Lake', 45, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (45, 'Williams Lake', 45, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (46, 'Princeton', 46, 1, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (46, 'Princeton', 46, 1, null, 1, 0);
 
-insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind) values (47, 'Shuswap Lake', 47, 2, null, 1);
+insert into office (office_id, office_name, office_number, sb_id, deleted, exams_enabled_ind, appointments_enabled_ind) values (47, 'Shuswap Lake', 47, 2, null, 1, 0);


### PR DESCRIPTION
During testing of new back-end features, it was found out that the pre-population scripts for offices was incomplete. This PR addresses adding the 'appointments_enabled' field and initializing each office in the table with a value of 0.