### PR TITLE
Exam Admin Re-name

### DIFF
--- a/frontend/src/layout/nav.vue
+++ b/frontend/src/layout/nav.vue
@@ -46,7 +46,7 @@
             <b-dropdown-item to="/queue">The Q</b-dropdown-item>
             <b-dropdown-item to="/booking" v-if="showExams">Room Booking</b-dropdown-item>
             <b-dropdown-item to="/appointments" v-if="showAppointments">Appointments</b-dropdown-item>
-            <b-dropdown-item to="/exams" v-if="showExams">Exam Admin</b-dropdown-item>
+            <b-dropdown-item to="/exams" v-if="showExams">Exam Inventory</b-dropdown-item>
             <b-dropdown-item to="/agenda" v-if="isGAorCSR && showExams">Office Agenda</b-dropdown-item>
             <template  v-if="user.role && user.role.role_code=='GA'">
               <b-dropdown-item @click="clickGAScreen" :class="gaPanelStyle">


### PR DESCRIPTION
Client testing found that 'Exam Admin' in the nav hamburger dropdown list should be re-named 'Exam Inventory' to match the page name. This PR contains that fix.