### PR TITLE
Exam Inventory - Delete Exam Not Working

### DIFF
--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -397,7 +397,6 @@
       },
       deleteExam() {
         let deleteExamInfo = {}
-
         if (this.fields.booking_id) {
           deleteExamInfo = {
             booking_id: this.fields.booking_id,

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -109,6 +109,7 @@ export const store = new Vuex.Store({
     offsiteVisible: false,
     performingAction: false,
     rescheduling: false,
+    returnExam: null,
     rooms: [],
     roomResources: [],
     scheduling: false,
@@ -1909,7 +1910,9 @@ export const store = new Vuex.Store({
       state.categories = []
       state.categories = payload
     },
-  
+
+    setReturnExamInfo: (state, payload) => state.returnExam = payload,
+
     toggleAddModal: (state, payload) => state.showAddModal = payload,
   
     updateAddModalForm(state, payload) {


### PR DESCRIPTION
Client testing found issues with deleting exams through the edit exam modal. This issue can be attributed to a previous refactor, and has been resolved.