### PR TITLE
Pesticide Exam Modal - Preset/Validate Exam for Pesticide Exam Type

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -152,10 +152,17 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
       <h5 v-if="addExamModal.setup === 'pesticide' ">Add Pesticide Exam</h5>
       <label>Exam Type</label><br>
         <div @click="clickInput">
-          <b-input read-only
+          <b-input v-if="addExamModal.setup !== 'pesticide'"
+                   read-only
                    autocomplete="off"
                    :value="inputText"
                    placeholder="click here to see options"
+                   :style="inputStyle" />
+          <b-input v-if="addExamModal.setup === 'pesticide'"
+                   read-only
+                   autocomplete="off"
+                   :value="inputText"
+                   placeholder="Pesticide"
                    :style="inputStyle" />
         </div>
         <div :class="dropclass"
@@ -164,7 +171,8 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
           <template v-for="type in dropItems">
             <b-dd-header v-if="type.header"
                          :style="{backgroundColor: type.exam_color}"
-                         :class="type.class">{{ type.exam_type_name }}</b-dd-header>
+                         :class="type.class">{{ type.exam_type_name }}
+                         :value="type.exam_</b-dd-header>
             <b-dd-item v-else :style="{backgroundColor: type.exam_color}"
                        @click="preHandleInput(type.exam_type_id)"
                        :name="type.exam_type_id"

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -268,7 +268,10 @@
         }
         if (setup === 'pesticide') {
           let value = moment().add(60, 'd')
+          let id = this.examTypes.find(ex => ex.exam_type_name.includes("Pesticide")).exam_type_id
           this.captureExamDetail({ key: 'expiry_date', value })
+          this.captureExamDetail({ key: 'exam_type_id', id})
+          this.$root.$emit('validateform')
         }
       },
       tryAgain() {


### PR DESCRIPTION
Client testing found that the Pesticide Exam modal needed the exam type value to be preset to "Pesticide". This PR contains the fix for this issue by pre-setting the exam_type_id once the modal is opened, and validating the exam_type_id as well, such that the user can continue through the steps for creating an exam.