### PR TITLE
Admin Panel - Designate Label Re-name

### DIFF
--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -45,10 +45,10 @@ class CSRConfig(Base):
     column_labels = {
         'username': 'Username',
         'office.office_name': 'Office',
-        'ita_designate': 'ITA Designate',
-        'pesticide_designate': 'Pesticide Exam Designate',
+        'ita_designate': 'Office Exam Manager',
+        'pesticide_designate': 'Pesticide Client Liaison/Program Specialist',
         'finance_designate': 'Financial Reporting Designate',
-        'liaison_designate': 'Liaison Designate',
+        'liaison_designate': 'ITA Liaison/Program Specialist',
         'role.role_desc': 'Role',
         'deleted': 'Deleted'
     }


### PR DESCRIPTION
Client testing found that ITA, Pesticide, and Liaison designates needed to be re-named to properly reflect the csr's job title. This has been addressed in this PR.

- ITA -> Office Exam Manager
- Pesticide -> Pesticide Client Liaison/Program Specialist
- Liaison -> ITA Liaison/Program Specialist