### PR TITLE
Input Field - Disable Autocomplete

### DIFF
--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -78,7 +78,8 @@
             <b-col>
               <b-form-group>
                 <label>Contact Information (Email or Phone Number)</label><br>
-                <b-input id="contact_information"
+                <b-input autocomplete="off"
+                         id="contact_information"
                          type="text"
                          @change="checkValue"
                          v-model="booking_contact_information"/>


### PR DESCRIPTION
Client testing found that vue input fields should have autocomplete disabled.

This was completed in a previous sprint, but developer testing found one field on the edit booking modal that didn't have this setting enabled.