### PR TITLE
Group Exam Time Select

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -634,7 +634,6 @@ export const TimeQuestion = Vue.component('time-question', {
                       lang="en"
                       @input="selectTime"
                       format="h:mm a"
-                      confirm
                       autocomplete="off"
                       placeholder="Select Time"
                       class="w-50"


### PR DESCRIPTION
Client testing found the "Ok" confirm at the bottom of the Exam Time select drop down was not necessary. This PR seeing the confirm option on the Time Question component removed to remedy this.