### PR TITLE
Need Collect Fees Yes/No

### DIFF
--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -68,8 +68,9 @@
             <b-col cols="3">
               <b-form-group>
                 <label>Collect Fees</label><br>
-                <b-select v-model="fees"
-                          @change="checkValue"
+                <b-select id="fees"
+                          v-model="fees"
+                          @change.native="checkValue"
                           :options="feesOptions" />
               </b-form-group>
             </b-col>
@@ -80,30 +81,8 @@
                 <label>Contact Information (Email or Phone Number)</label><br>
                 <b-input id="contact_information"
                          type="text"
-                         @change="checkValue"
+                         @change.native="checkValue"
                          v-model="booking_contact_information"/>
-              </b-form-group>
-            </b-col>
-          </b-form-row>
-          <b-form-row v-if="fees">
-            <b-col cols="4">
-              <b-form-group>
-                <label>Fee Option</label>
-                <b-select :options="roomRates" v-model="rate" />
-              </b-form-group>
-            </b-col>
-            <b-col cols="8">
-              <b-form-group>
-                <label>Invoice To</label>
-                <b-select :options="invoiceOptions" v-model="invoice"/>
-              </b-form-group>
-            </b-col>
-          </b-form-row>
-          <b-form-row v-if="invoice==='custom'">
-            <b-col cols="12">
-              <b-form-group>
-                <label>Enter Name of Entity to Invoice</label><br>
-                <b-input />
               </b-form-group>
             </b-col>
           </b-form-row>
@@ -224,7 +203,10 @@
         invigilator: null,
         editedFields: [],
         fees: false,
-        feesOptions: [ {text: 'No', value: false}, ],
+        feesOptions: [
+          {text: 'No', value: "false"},
+          {text: 'Yes', value: "true"},
+        ],
         invoice: null,
         invoiceOptions: [ {text: 'Custom', value: 'custom'} ],
         labelColor: 'black',
@@ -535,8 +517,8 @@
         if (this.editedFields.includes('title')) {
           changes['booking_name'] = this.title
         }
-        if (this.editedFields.includes('fee')) {
-          changes['fees'] = this.fee
+        if (this.editedFields.includes('fees')) {
+          changes['fees'] = this.fees
         }
         if (this.editedFields.includes('invigilator')) {
           changes.invigilator_id = this.invigilator
@@ -548,7 +530,9 @@
             changes.sbc_staff_invigilated = 1
           }
         }
-        changes['booking_contact_information'] = this.booking_contact_information
+        if (this.editedFields.includes('contact_information')){
+          changes['booking_contact_information'] = this.booking_contact_information
+        }
         if (Object.keys(changes).length === 0) {
           this.message = 'No Changes Made'
         } else {


### PR DESCRIPTION
Client testing found that the Collect Fees dropdown on the edit booking modal only had the "No" value enabled, and required a "Yes" value as well. This field had to map correctly to the fees field on the booking model. This PR adds this dropdown option and also ensures that the Put method to edit a particular booking works for this field now that it has been enabled.

Client also asked that the the 3 fields (fee amount, invoice to, name of entity to bill) that were enabled when the fees option was set to yes, were also to be removed, to be possibly implemented at a later date.