### PR TITLE
Booking Calendar - Booking Events in the Past

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -115,6 +115,10 @@
         config: {
           columnHeaderFormat: 'ddd/D',
           selectAllow: (info) => {
+            let today = moment()
+            if(info.start.isBefore(today)){
+              return false
+            }
             if (this.scheduling || this.rescheduling) {
               return true
             }
@@ -190,6 +194,7 @@
         'selectedExam',
         'showBookingModal',
         'showExamInventoryModal',
+        'showStartDateModal',
       ]),
       adjustment() {
         if (this.scheduling || this.rescheduling) {
@@ -248,6 +253,7 @@
         'toggleOffsiteVisible',
         'toggleOtherBookingModal',
         'toggleScheduling',
+        'toggleStartDateModalVisible',
       ]),
       agendaDay() {
         this.$refs.bookingcal.fireMethod('changeView', 'agendaDay')


### PR DESCRIPTION
Client testing found that bookings could be done in the past, which should not be allowed. This PR corrects this by adding logic to the config object of the calendar, checking to see if the start date of the event being created is before a datetime object called "Today" which goes down the minute value of the datetime object created. Example: If the time of the object created is 3:03pm of that day, the calendar will not allow you to create an event until the 3:30pm-4:00pm block.