### PR TITLE
Responsive Exam Inventory Table

### DIFF
--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -117,6 +117,7 @@
                @row-clicked="clickModalRow"
                hover
                show-empty
+               responsive
                :current-page="page"
                :per-page="10"
                :filter="searchTerm">


### PR DESCRIPTION
Client testing found that if a user with vision impairment zooms in on the exam inventory table, that it didn't have a horizontal scroll automatically enabled. This was fixed by adding the 'responsive' prop to the b-table on the exam-inventory table component, and tested by zooming on the component to see whether or not a scroll bar became active if the component was larger than the actual screensize of the user.