### PR TITLE
Liaison Designate Exam Inventory Bug

### DIFF
--- a/api/app/resources/bookings/exam/exam_list.py
+++ b/api/app/resources/bookings/exam/exam_list.py
@@ -38,7 +38,7 @@ class ExamList(Resource):
             if csr.liaison_designate == 1:
                 exams = Exam.query.filter(Exam.deleted_date.is_(None))\
                                   .filter(or_(Exam.exam_returned_date.is_(None),
-                                              Exam.exam_returned_date > ninety_day_filter)).all
+                                              Exam.exam_returned_date > ninety_day_filter))
 
             else:
                 exams = Exam.query.filter(Exam.deleted_date.is_(None))\


### PR DESCRIPTION
Client testing found a bug in the exam_list endpoint when a csr had the liaison designate ind set to 1. The .all method was removed from the query object to resolve this.`