### PR TITLE
Postman Environment Variables

### DIFF
--- a/api/postman/bookings-env-postman.json
+++ b/api/postman/bookings-env-postman.json
@@ -1,8 +1,69 @@
 {
 	"id": "c35aa2f8-b9f5-40c2-8ff0-0dd00ecbbca6",
 	"name": "bookings-end-point-testing-dev",
-	"values": [],
+	"values": [
+		{
+			"key": "auth_url",
+			"value": "http://localhost:8085/auth/realms/registry/protocol/openid-connect/auth",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "postman_bdd_path",
+			"value": "https://raw.githubusercontent.com/JamesMessinger/postman-bdd/master/dist/postman-bdd.min.js\n",
+			"description": "",
+			"enabled": false
+		},
+		{
+			"key": "postmanBDD",
+			"value": "",
+			"description": "",
+			"enabled": false
+		},
+		{
+			"key": "clientid",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "userid",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "password",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "client_secret",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "realm",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "expires_in",
+			"value": "1800",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "refresh_expires_in",
+			"value": "7200",
+			"description": "",
+			"enabled": true
+		}
+	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2018-12-11T19:36:35.882Z",
-	"_postman_exported_using": "Postman/6.6.0"
+	"_postman_exported_at": "2019-04-10T19:30:07.414Z",
+	"_postman_exported_using": "Postman/7.0.7"
 }


### PR DESCRIPTION
Client pointed out that refreshed enviornment variables weren't sent on the lastest PR. These were changed over a month ago with the move to localhost keycloak, but forgotten.