### PR TITLE
Ensure that edit exam modal closes when we delete an exam

### DIFF
--- a/frontend/src/exams/delete-exam-modal.vue
+++ b/frontend/src/exams/delete-exam-modal.vue
@@ -43,13 +43,15 @@
             'getExams',
           ]),
           ...mapMutations([
-            'toggleDeleteExamModalVisible'
+            'toggleDeleteExamModalVisible',
+            'toggleEditExamModal',
           ]),
           clickYes() {
             let exam_id = this.returnExam.exam_id
             this.deleteExam(exam_id)
                 .then(() => { this.getExams() })
             this.toggleDeleteExamModalVisible(false)
+            this.toggleEditExamModal(false)
             if (this.returnExam.booking_id){
               this.deleteBooking(this.returnExam.booking_id)
             }


### PR DESCRIPTION
After deleting an exam, the edit exam modal continues to display in the background. This change ensures that it closes correctly.