### PR TITLE
Sprint 10 3 generate csv access

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4952,8 +4952,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4974,14 +4973,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4996,20 +4993,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5126,8 +5120,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5139,7 +5132,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5154,7 +5146,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5162,14 +5153,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5188,7 +5177,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5269,8 +5257,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5282,7 +5269,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5368,8 +5354,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5405,7 +5390,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5425,7 +5409,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5469,14 +5452,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -1,14 +1,9 @@
 <template v-if="showExams">
-  <div class="q-w100-flex-fe pr-3" v-if="is_financial_designate">
-    <b-button class="btn-primary mr-3"
-              @click="clickGenFinReport">Generate Financial Report</b-button>
-    <FinancialReportModal />
-  </div>
-  <div class="q-w100-flex-fs" v-else>
+  <div class="q-w100-flex-fs">
     <b-form inline>
       <b-dd v-if="role_code === 'GA'"
             split
-            class="mr-2"
+            class="mr-1"
             variant="primary"
             text="Add ITA Exam"
             @click="handleClick('individual')">
@@ -23,8 +18,12 @@
       <b-button class="mr-1 btn-primary"
                 @click="handleClick('other')">Add Other Exam</b-button>
       <b-button v-if="is_pesticide_designate"
-                class="btn-primary"
+                class="mr-1 btn-primary"
                 @click="handleClick('pesticide')">Add Pesticide Exam</b-button>
+      <b-button v-if="is_financial_designate || role_code === 'GA' || is_ita_designate"
+                class="btn-primary mr-3"
+                @click="clickGenFinReport">Generate Financial Report</b-button>
+    <FinancialReportModal />
     </b-form>
     <AddExamModal />
   </div>


### PR DESCRIPTION
During the handoff meeting, clients determined that this button should now be viewable by users with the ita_designate and financial_designate fields set to 1 and if a user is also a GA. This button was also modified to no longer be justified right on the button row, and is now in line with the rest of the buttons that show up on the exam inventory page.