### PR TITLE
Exam Type Admin Panel - Ind Re-name

### DIFF
--- a/api/app/admin/examtype.py
+++ b/api/app/admin/examtype.py
@@ -22,13 +22,14 @@ class ExamTypeConfig(Base):
     roles_allowed = ['SUPPORT']
 
     def is_accessible(self):
-        return  current_user.is_authenticated and current_user.role.role_code in self.roles_allowed
+        return current_user.is_authenticated and current_user.role.role_code in self.roles_allowed
 
     def get_query(self):
         return self.session.query(self.model)
 
     create_modal = False
     edit_modal = False
+
     column_list = [
         'exam_type_name',
         'exam_color',
@@ -37,6 +38,15 @@ class ExamTypeConfig(Base):
         'ita_ind',
         'group_exam_ind'
     ]
+
+    column_labels = {
+        'exam_type_name': 'Exam Type Name',
+        'exam_color': 'Exam Color',
+        'number_of_hours': 'Number of Hours',
+        'method_type': 'Method Type',
+        'ita_ind': 'ITA Exam Flag',
+        'group_exam_ind': 'Group Exam Flag',
+    }
 
     column_searchable_list = {'exam_type_name'}
 
@@ -53,14 +63,14 @@ class ExamTypeConfig(Base):
         'group_exam_ind'
     )
 
-    form_edit_rules = (
-        'exam_type_name',
-        'exam_color',
-        'number_of_hours',
-        'method_type',
-        'ita_ind',
-        'group_exam_ind'
-    )
+    form_edit_rules = {
+        'exam_type_name': 'Exam Type Name',
+        'exam_color': 'Exam Color',
+        'number_of_hours': 'Number of Hours',
+        'method_type': 'Method Type',
+        'ita_ind': 'ITA Exam Flag',
+        'group_exam_ind': 'Group Exam Flag',
+    }
 
     column_sortable_list = [
         'exam_type_name',


### PR DESCRIPTION
Client testing found that columns labels with "_ind" were confusing (ind->individual, not ind->indicator), so this was changed to label the list table and table column fields to show 'Flag' instead of 'Ind'.