### PR TITLE
Chanllenger Exams - Show if User is Office Manager

### DIFF
--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -6,7 +6,7 @@
   </div>
   <div class="q-w100-flex-fs" v-else>
     <b-form inline>
-      <b-dd v-if="role_code === 'GA'"
+      <b-dd v-if="role_code === 'GA' || is_ita_designate"
             split
             class="mr-2"
             variant="primary"


### PR DESCRIPTION
During final client testing, it was found that the challenger/monthly sessional drop down needed to be visible to users with the office manager flag set to 1. This was resolved by adding the 'is_ita_designate' getting to the logic that controls whether or not this dropdown component is visible.