### PR TITLE
Calendar Event Width

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -280,6 +280,7 @@
         this.$refs.bookingcal.fireMethod('updateEvent', event)
       },
       eventRender(event, el, view) {
+        el.css('width', '85%')
         if (event.exam && view.name === 'listYear') {
           el.find('td.fc-list-item-title.fc-widget-content').html(
           `<div style="display: flex; justify-content: center; width: 100%;">


### PR DESCRIPTION
Clients asked for the calendar events to show up with ~90% width of the calendar room column to allow users to place more than one event in the same time slot. I've confirmed that the 85% width the event is currently set to is satisfactory with the client already.