### PR TITLE
Pesticide Exam - Revert Exam Type Changes

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -158,17 +158,10 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
       <h5 v-if="addExamModal.setup === 'pesticide' ">Add Pesticide Exam</h5>
       <label>Exam Type</label><br>
         <div @click="clickInput">
-          <b-input v-if="addExamModal.setup !== 'pesticide'"
-                   read-only
+          <b-input read-only
                    autocomplete="off"
                    :value="inputText"
                    placeholder="click here to see options"
-                   :style="inputStyle" />
-          <b-input v-if="addExamModal.setup === 'pesticide'"
-                   read-only
-                   autocomplete="off"
-                   :value="inputText"
-                   placeholder="Pesticide"
                    :style="inputStyle" />
         </div>
         <div :class="dropclass"
@@ -177,8 +170,7 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
           <template v-for="type in dropItems">
             <b-dd-header v-if="type.header"
                          :style="{backgroundColor: type.exam_color}"
-                         :class="type.class">{{ type.exam_type_name }}
-                         :value="type.exam_</b-dd-header>
+                         :class="type.class">{{ type.exam_type_name }}</b-dd-header>
             <b-dd-item v-else :style="{backgroundColor: type.exam_color}"
                        @click="preHandleInput(type.exam_type_id)"
                        :name="type.exam_type_id"

--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -107,7 +107,7 @@ export const DropdownQuestion = Vue.component('dropdown-question',{
         let exams = this.examTypes.filter(type =>
           type.pesticide_exam_ind === 1 &&
           type.group_exam_ind === 0);
-        return exams
+        return exams.sort((a,b) => sorter(a,b))
       }
     },
     inputText() {

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -269,10 +269,7 @@
         }
         if (setup === 'pesticide') {
           let value = moment().add(60, 'd')
-          let id = this.examTypes.find(ex => ex.exam_type_name.includes("Pesticide")).exam_type_id
           this.captureExamDetail({ key: 'expiry_date', value })
-          this.captureExamDetail({ key: 'exam_type_id', id})
-          this.$root.$emit('validateform')
         }
       },
       tryAgain() {


### PR DESCRIPTION
Client has asked that the default exam type change that was made in commit
12d4014 be reverted since there are now going to be 3 different pesticide exam types (accounting for duration). A sort of the exam types has also been applied such that the list will now mirror functionality of all other exam type selections in all other add exam modal types.
