### PR TITLE
Fixed issue preventing Capture of Monthly Session Exams

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -721,7 +721,7 @@ class Bootstrap(Command):
         )
 
         exam_type_sixteen = bookings.ExamType(
-            exam_type_name="Challenger Exam Session",
+            exam_type_name="Monthly Session Exam",
             exam_color="#FFFFFF",
             number_of_hours=4,
             method_type="Written",

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1632,7 +1632,7 @@ export const store = new Vuex.Store({
         start_time: start.clone().utc().format('YYYY-MM-DD[T]HH:mm:ssZ'),
         end_time: end.clone().utc().format('YYYY-MM-DD[T]HH:mm:ssZ'),
         fees: 'false',
-        booking_name: 'Monthly Session',
+        booking_name: responses.exam_name,
         office_id: context.state.user.office_id,
       }
       if (responses.on_or_off === 'on') {


### PR DESCRIPTION
Due to changes of the name of the above type of exam which were not updated throughout the frontend code, the examObject for that type of exam could not be located by searching by name and thus the exam details could not be populated for posting.  Have updated.