### PR TITLE
Two Add ITA Exam Buttons

### DIFF
--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -11,7 +11,7 @@
         <b-dd-item id="add_session"
                    @click="handleClick('challenger')">Add Monthly Session Exam</b-dd-item>
       </b-dd>
-      <b-button v-if="role_code!=='GA'"
+      <b-button v-if="!(role_code === 'GA' || is_ita_designate)"
                 id="add_ita"
                 class="mr-1 btn-primary"
                 @click="handleClick('individual')">Add ITA Exam</b-button>


### PR DESCRIPTION
Client testing found that if a user had the Office Manager permission set to 1 and wasn't a GA, that two Add ITA Exam buttons would show on the exam invetory page. This issue was fixed by fixing partial logic on the buttons-exams such that a negation is now complete.