### PR TITLE
Notification Z-Index

### DIFF
--- a/frontend/src/exam-alert.vue
+++ b/frontend/src/exam-alert.vue
@@ -18,7 +18,7 @@ limitations under the License.*/
              variant="primary"
              dismissible
              :show="examDismissCount"
-             style="h-align: center; font-size:1rem; border-radius: 0px; z-index: 1041"
+             style="h-align: center; font-size:1rem; border-radius: 0px;"
              @dismissed="onDismissedExam">
              {{ examAlertMessage }}
     </b-alert>


### PR DESCRIPTION
Client testing found that the notification banner was being rendering over top of modals. This was fixing by reducing the the z-index of the notification banner from 1041 to 1040.