### PR TITLE
Need Collect Fees Yes/No

### DIFF
--- a/frontend/src/booking/edit-booking-modal.vue
+++ b/frontend/src/booking/edit-booking-modal.vue
@@ -203,7 +203,7 @@
         added: 0,
         invigilator: null,
         editedFields: [],
-        fees: false,
+        fees: '',
         feesOptions: [
           {text: 'No', value: "false"},
           {text: 'Yes', value: "true"},
@@ -480,8 +480,8 @@
         if (!this.editedFields.includes('title')) {
           this.title = this.event.title
         }
-        if (!this.editedFields.includes('fee')) {
-          this.fee = this.event.fee
+        if (!this.editedFields.includes('fees')) {
+          this.fees = this.event.fees
         }
         if (!this.editedFields.includes('booking_contact_information')){
           this.booking_contact_information = this.event.booking_contact_information

--- a/frontend/src/booking/other-booking-modal.vue
+++ b/frontend/src/booking/other-booking-modal.vue
@@ -30,35 +30,14 @@
               <b-col cols="5">
                 <b-form-group>
                   <label>Collect Fees</label><br>
-                  <b-select v-model="fees" :options="feesOptions" />
+                  <b-select v-model="fees"
+                            :options="feesOptions" />
                 </b-form-group>
               </b-col>
               <b-col cols="7">
                 <b-form-group>
                   <label>Room</label>
                   <b-input readonly :value="resource.title" />
-                </b-form-group>
-              </b-col>
-            </b-form-row>
-            <b-form-row v-if="fees">
-              <b-col cols="4">
-                <b-form-group>
-                  <label>Fee Option</label>
-                  <b-select :options="roomRates" v-model="rate" />
-                </b-form-group>
-              </b-col>
-              <b-col cols="8">
-                <b-form-group>
-                  <label>Invoice To</label>
-                  <b-select :options="invoiceOptions" v-model="invoice"/>
-                </b-form-group>
-              </b-col>
-            </b-form-row>
-            <b-form-row v-if="invoice==='custom'">
-              <b-col cols="12">
-                <b-form-group>
-                  <label>Enter Name of Entity to Invoice</label><br>
-                  <b-input />
                 </b-form-group>
               </b-col>
             </b-form-row>
@@ -126,18 +105,12 @@
         title: '',
         state: null,
         message: '',
-        fees: false,
+        fees: '',
         feesOptions: [
-          {text: 'No', value: false},
+          {text: 'No', value: "false"},
+          {text: 'Yes', value: "true"}
         ],
         added: 0,
-        roomRates: [
-          {value: 125, text: '$125 for 1/2 Day'},
-          {value: 250, text: '$250 for Whole Day'}
-        ],
-        invoiceOptions: [
-          {text: 'Custom', value: 'custom'}
-        ],
         invoice: null,
         rate: null,
         start:'',
@@ -242,7 +215,7 @@
             room_id: this.resource.id,
             start_time: start.format('DD-MMM-YYYY[T]HH:mm:ssZ'),
             end_time: end.format('DD-MMM-YYYY[T]HH:mm:ssZ'),
-            fees: 'false',
+            fees: this.fees,
             booking_name: this.title,
             booking_contact_information: this.contact_information,
           }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -544,7 +544,7 @@ export const store = new Vuex.Store({
             booking.id = b.booking_id
             booking.exam = context.state.exams.find(ex => ex.booking_id == b.booking_id) || false
             booking.booking_contact_information = b.booking_contact_information
-
+            booking.fees = b.fees
             calendarEvents.push(booking)
           })
           context.commit('setEvents', calendarEvents)


### PR DESCRIPTION
Client testing found that the Collect Fees dropdown on the edit booking modal only had the "No" value enabled, and required a "Yes" value as well. This field had to map correctly to the fees field on the booking model. This PR adds this dropdown option and also ensures that the Put method to edit a particular booking works for this field now that it has been enabled.

Client also asked that the the 3 fields (fee amount, invoice to, name of entity to bill) that were enabled when the fees option was set to yes, were also to be removed, to be possibly implemented at a later date.