### PR TITLE
Click Once Submit Buttons

### DIFF
--- a/frontend/src/booking/booking-modal.vue
+++ b/frontend/src/booking/booking-modal.vue
@@ -128,7 +128,7 @@
                                  class="ml-1 p-0"
                                  style="font-size: 1rem;"/></b-button></div>
           <div v-if="selectedOption !== 'invigilator' || formStep === 2">
-            <b-button @click="submit"
+            <b-button @click.once="submit"
                       :disabled="buttonStatus"
                       class="mt-3 ml-1 btn-primary">Submit</b-button></div>
         </div>

--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -48,7 +48,7 @@
                       id="add_exam_submit">Submit</b-button>
             <b-button v-else
                       class="btn-primary"
-                      @click="submit"
+                      @click.once="submit"
                       id="add_exam_submit">Submit</b-button>
           </div>
         </div>
@@ -351,6 +351,7 @@
     }
   }
 </script>
+
 
 <style>
   .message-text {

--- a/frontend/src/exams/success-exam-alert.vue
+++ b/frontend/src/exams/success-exam-alert.vue
@@ -18,7 +18,7 @@ limitations under the License.*/
       variant="success"
       dismissible
       v-model="countdown"
-      @dismissed="setExamEditSuccess(0)"
+      @dismissed="setEditExamSuccess"
        style="h-align: center; font-size:1rem; border-radius: 0px;">
       Success!
     </b-alert>


### PR DESCRIPTION
Client noted that during slow network periods that clicking submit buttons on create exams or create bookings would create multiple instances of that object. This has been resolved by adding '.once' to the @click property of the submit buttons on the add exam modal and add booking modal.