### PR TITLE
Fixed Issue that prevented booking of session exams in office

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -21,6 +21,7 @@ limitations under the License.*/
       <ExamAlert />
       <SuccessExamAlert />
       <Nav v-if="isLoggedIn" />
+      <AddExamModal />
       <Feedback />
       <Response />
     </div>
@@ -43,10 +44,12 @@ limitations under the License.*/
   import Response from './response'
   import Socket from './Socket'
   import SuccessExamAlert from './exams/success-exam-alert'
+  import AddExamModal from './exams/add-exam-modal'
 
   export default {
     name: 'App',
     components: {
+      AddExamModal,
       Alert,
       ExamAlert,
       FailureExamAlert,

--- a/frontend/src/assets/css/q.css
+++ b/frontend/src/assets/css/q.css
@@ -32,6 +32,16 @@
   padding: 1%;
   position: relative;
 }
+.q-custom-booking-modal {
+  background-color: #fefefe;
+  margin-right: auto;
+  margin-left: auto;
+  margin-top: 3%;
+  width: 525px;
+  padding: 1%;
+  position: relative;
+  border-radius: 5px;
+}
 .q-modal-body {
   padding: 0px !important;
 }

--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -116,6 +116,9 @@
         config: {
           columnHeaderFormat: 'ddd/D',
           selectAllow: (info) => {
+            if (info.resourceId === '_offsite') {
+              return false
+            }
             let today = moment()
             if(info.start.isBefore(today)){
               return false

--- a/frontend/src/booking/scheduling-indicator.vue
+++ b/frontend/src/booking/scheduling-indicator.vue
@@ -66,7 +66,7 @@
       }
     },
     methods: {
-      ...mapActions(['finishBooking', 'actionRestoreAll']),
+      ...mapActions(['finishBooking', ]),
       ...mapMutations(['toggleEditBookingModal']),
       cancel() {
         if (this.rescheduling) {
@@ -79,9 +79,7 @@
         }
         this.finishBooking()
         if (pushToExams) {
-          this.actionRestoreAll().then( () => {
-            this.$router.push('/exams')
-          })
+          this.$router.push('/exams')
         }
       }
     }

--- a/frontend/src/exams/buttons-exams.vue
+++ b/frontend/src/exams/buttons-exams.vue
@@ -31,18 +31,16 @@
                 @click="clickGenFinReport">Generate Financial Report</b-button>
     <FinancialReportModal />
     </b-form>
-    <AddExamModal />
   </div>
 </template>
 
 <script>
   import { mapActions, mapMutations, mapState, mapGetters } from 'vuex'
-  import AddExamModal from './add-exam-modal'
   import FinancialReportModal from './generate-financial-report-modal'
 
   export default {
     name: "ButtonsExams",
-    components: { AddExamModal, FinancialReportModal },
+    components: { FinancialReportModal },
     computed: {
       ...mapState(['addNonITA', 'showGenFinReportModal', 'user' ]),
       ...mapGetters([
@@ -55,7 +53,6 @@
       ]),
     },
     methods: {
-      ...mapActions(['actionRestoreAll']),
       ...mapMutations(['setAddExamModalSetting', 'toggleGenFinReport',]),
       handleClick(type) {
         this.setAddExamModalSetting({setup: type})

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -187,11 +187,11 @@
                      class="ml-3 mt-1">Scheduling</div>
               </template>
               <template v-else-if="row.item.exam_type.exam_type_name.includes('Group')">
-                <div v-if="!row.item.booking.invigilator_id"
+                <div v-if="!checkInvigilator(row.item)"
                      class="ml-3 mt-1">Assignment of Invigilator</div>
               </template>
               <template v-else-if="row.item.exam_type.exam_type_name === 'Monthly Session Exam'">
-                <div v-if="!row.item.booking.invigilator_id"
+                <div v-if="!checkInvigilator(row.item)"
                      class="ml-3 mt-1">Assignment of Invigilator</div>
                 <div v-if="!row.item.number_of_students"
                      class="ml-3 mt-1">Number of Students</div>
@@ -470,6 +470,7 @@
         return false
       },
       checkInvigilator(item) {
+        console.log(item)
         if (item.booking && (item.booking.invigilator_id || item.booking.sbc_staff_invigilated)) {
           return true
         }

--- a/frontend/src/store/add-exam-module.js
+++ b/frontend/src/store/add-exam-module.js
@@ -508,97 +508,31 @@ export const addExamModule = {
           ]
       },
     ],
-    capturedExam: {},
-    captureITAExamTabSetup: {},
-    addExamModal: {},
-    booking: {},
-    
+    challengerBooking: {},
   },
   actions: {
-    actionSaveAll(context) {
-      return new Promise((resolve, reject) => {
-        context.dispatch('actionCapturedExam').then( () => {
-          context.dispatch('actionCaptureITAExamTabSetup').then( () => {
-            context.dispatch('actionAddModalSetup').then( () => {
-              resolve()
-            })
-          })
-        })
-      })
+    clearChallengerBooking({commit}) {
+      commit('clearChallengerBooking')
+      commit('clearAddExamModalFromCalendarStatus')
     },
-    actionRestoreAll(context) {
-      let savedProps = ['capturedExam', 'captureITAExamTabSetup', 'addExamModal']
-      savedProps.forEach(key => {
-        let name = key
-        let item = Object.assign({}, context.state[key])
-        context.commit('restoreSavedModal', {name, item})
-      })
-    },
-    actionWipeAll({commit}) {
-      commit('wipeAll')
-    },
-    actionCapturedExam({commit, rootState}) {
-      commit('saveCapturedExam', Object.assign({}, rootState.capturedExam))
-    },
-    actionCaptureITAExamTabSetup({commit, rootState}) {
-      commit('saveCaptureITAExamTabSetup', Object.assign({}, rootState.captureITAExamTabSetup))
-    },
-    actionAddModalSetup({commit, rootState}) {
-      commit('saveAddModalSetup', Object.assign({}, rootState.addExamModal))
-    },
-    actionWipeAllSavedModals({commit}) {
-      commit('wipeAll')
-    }
   },
   mutations: {
-    wipeAll(state, payload) {
-      let keys = [ 'capturedExam', 'captureITAExamTabSetup', 'addExamModal', 'booking' ]
-      keys.forEach(key => {
-        Vue.set(
-          state,
-          key,
-          null
-        )
-      })
-    },
-    saveBooking(state, payload) {
-      Object.keys(payload).forEach(key => {
-        Vue.set(
-          state.booking,
-          key,
-          payload[key]
-        )
-      })
-    },
-    saveCapturedExam(state, payload) {
-      Object.keys(payload).forEach(key => {
-        if (payload[key] === null) {
-          payload[key] = ''
+    saveChallengerBooking(state, payload) {
+      Object.keys(payload).forEach( key => {
+        if (payload[key]) {
+          Vue.set(
+            state.challengerBooking,
+            key,
+            payload[key]
+          )
         }
-        Vue.set(
-          state.capturedExam,
-          key,
-          payload[key]
-        )
       })
     },
-    saveCaptureITAExamTabSetup(state, payload) {
-      Object.keys(payload).forEach(key => {
-        Vue.set(
-          state.captureITAExamTabSetup,
-          key,
-          payload[key]
-        )
-      })
-    },
-    saveAddModalSetup(state, payload) {
-      Object.keys(payload).forEach(key => {
-        Vue.set(
-          state.addExamModal,
-          key,
-          payload[key]
-        )
-      })
+    clearChallengerBooking(state) {
+      Vue.delete(
+        state,
+        'challengerBooking'
+      )
     }
   }
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1640,7 +1640,12 @@ export const store = new Vuex.Store({
         delete responses.offsite_location
       }
       if (responses.invigilator) {
-        booking.invigilator_id = responses.invigilator.invigilator_id.valueOf()
+        if (responses.invigilator === 'sbc') {
+          booking.invigilator_id = null
+          booking.sbc_staff_invigilated = true
+        } else {
+          booking.invigilator_id = responses.invigilator.invigilator_id.valueOf()
+        }
         delete responses.invigilator
       }
       let exam_type= context.state.examTypes.find(ex => ex.exam_type_name === 'Monthly Session Exam')
@@ -1648,7 +1653,8 @@ export const store = new Vuex.Store({
         exam_returned_ind: 0,
         examinee_name: 'Monthly Session',
         exam_type_id: exam_type.exam_type_id,
-        office_id: context.state.user.office_id
+        office_id: context.state.user.office_id,
+        exam_method: 'paper',
       }
       delete responses.exam_time
       delete responses.expiry_date
@@ -2010,6 +2016,10 @@ export const store = new Vuex.Store({
         csr_state_id: context.state.user.csr_state_id,
       })
     },
+  
+    restoreSavedModalAction({commit}, payload) {
+      commit('restoreSavedModal', payload)
+    },
   },
 
   mutations: {
@@ -2033,9 +2043,9 @@ export const store = new Vuex.Store({
       state.categories = []
       state.categories = payload
     },
-
+  
     setReturnExamInfo: (state, payload) => state.returnExam = payload,
-
+  
     toggleAddModal: (state, payload) => state.showAddModal = payload,
   
     updateAddModalForm(state, payload) {
@@ -2120,7 +2130,7 @@ export const store = new Vuex.Store({
       let service_citizen = citizen
       let priority = citizen.priority
       let counter = citizen.counter_id
-
+    
       let obj = { citizen_comments, activeQuantity, citizen_id, service_citizen, priority, counter }
       let keys = Object.keys(obj)
     
@@ -2185,7 +2195,7 @@ export const store = new Vuex.Store({
       state.examAlertMessage = payload
       state.examDismissCount = 999
     },
-
+  
     setLoginAlert(state, payload) {
       state.loginAlertMessage = payload
       state.loginDismissCount = 999
@@ -2241,8 +2251,8 @@ export const store = new Vuex.Store({
     examDismissCountDown(state, payload) {
       state.examDismissCount = payload
     },
-
-    loginDismissCountDown(state, payload){
+  
+    loginDismissCountDown(state, payload) {
       state.loginDismissCount = payload
     },
   
@@ -2259,27 +2269,27 @@ export const store = new Vuex.Store({
     setReceptionistState: (state, payload) => {
       state.user.receptionist_ind = payload
     },
-
+  
     setCounterStatusState: (state, payload) => {
       state.user.counter_id = payload
     },
-
+  
     setCSRState: (state, payload) => state.user.csr_state_id = payload,
   
     setUserCSRStateName: (state, payload) => state.user.csr_state.csr_state_name = payload,
-
+  
     setQuickList: (state, payload) => state.user.office.quick_list = payload,
-    
+  
     setBackOfficeList: (state, payload) => state.user.office.back_office_list = payload,
   
     setOffice: (state, officeType) => state.officeType = officeType,
-
+  
     setDefaultCounter: (state, defaultCounter) => {
       state.addModalForm.counter = defaultCounter.counter_id
       state.serviceModalForm.counter = defaultCounter.counter_id
       _default_counter_id = defaultCounter.counter_id
     },
-
+  
     flashServeNow: (state, payload) => state.serveNowStyle = payload,
   
     setServeNowAction: (state, payload) => state.serveNowAltAction = payload,
@@ -2325,6 +2335,15 @@ export const store = new Vuex.Store({
           payload[key]
         )
       })
+    },
+  
+    resetAddExamModal: (state) => {
+      state.addExamModal = {
+        visible: false,
+        setup: null,
+        step1MenuOpen: false,
+        office_number: null,
+      }
     },
   
     toggleGenFinReport(state, payload) {
@@ -2388,7 +2407,7 @@ export const store = new Vuex.Store({
         payload
       )
     },
-
+  
     setBookings(state, payload) {
       state.bookings = payload
     },
@@ -2396,7 +2415,7 @@ export const store = new Vuex.Store({
     setRooms(state, payload) {
       state.rooms = payload
     },
-
+  
     toggleBookingModal: (state, payload) => state.showBookingModal = payload,
   
     setClickedDate: (state, payload) => state.clickedDate = payload,
@@ -2408,7 +2427,7 @@ export const store = new Vuex.Store({
     toggleReturnExamModal: (state, payload) => state.showReturnExamModal = payload,
   
     toggleDeleteExamModalVisible: (state, payload) => state.showDeleteExamModal = payload,
-    
+  
     setSelectedExam(state, payload) {
       if (payload === 'clearGoto') {
         delete state.selectedExam.gotoDate
@@ -2416,7 +2435,7 @@ export const store = new Vuex.Store({
       }
       state.selectedExam = payload
     },
-
+  
     toggleScheduling: (state, payload) => {
       if (!payload) {
         state.scheduling = payload
@@ -2435,7 +2454,7 @@ export const store = new Vuex.Store({
     setEditExamFailure: (state, payload) => state.editExamFailureCount = payload,
   
     toggleEditBookingModal: (state, payload) => state.showEditBookingModal = payload,
-
+  
     setEditedBooking(state, payload) {
       if (typeof payload === 'object' && payload !== null) {
         state.editedBooking = Object.assign({}, payload)
@@ -2445,17 +2464,17 @@ export const store = new Vuex.Store({
         state.editedBookingOriginal = null
       }
     },
-
+  
     toggleRescheduling: (state, payload) => state.rescheduling = payload,
-
+  
     setEditedBookingOriginal: (state, payload) => state.editedBookingOriginal = payload,
   
     setOffices: (state, payload) => state.offices = payload,
   
     setOfficeFilter: (state, payload) => state.officeFilter = payload,
-
+  
     setSelectionIndicator: (state, payload) => state.selectionIndicator = payload,
-    
+  
     setResources: (state, payload) => state.roomResources = payload,
   
     setEvents: (state, payload) => state.calendarEvents = payload,
@@ -2464,9 +2483,9 @@ export const store = new Vuex.Store({
       let bookingCopy = Object.assign({}, booking)
       state.editedBooking = bookingCopy
     },
-
+  
     toggleEditGroupBookingModal: (state, payload) => state.showEditGroupBookingModal = payload,
-
+  
     setInventoryFilters(state, payload) {
       state.inventoryFilters[payload.type] = payload.value
     },
@@ -2482,9 +2501,11 @@ export const store = new Vuex.Store({
     },
   
     toggleOffsiteVisible: (state, payload) => state.offsiteVisible = payload,
-    
+  
     toggleExamsTrackingIP: (state, payload) => state.examsTrackingIP = payload,
   
     setAppointmentsStateInfo: (state, payload) => state.appointmentsStateInfo = payload,
+  
+    clearAddExamModalFromCalendarStatus: state => Vue.delete(state.addExamModal, 'fromCalendar'),
   }
 })


### PR DESCRIPTION
As the AddExamModal received no props, eliminated the need to save its state into another store key before switching routes to use the Calendar.  Now that the AddExamModal persists and is not destroyed on route changes there is no need to save and re-load its state.  Removed numerous actions, mutations, state keys and methods accross AddExamModal, BookingModal, AddExamModule and AddModalFormComponents.  Booking on-site now works.