### PR TITLE
Calendar Event Bleeding

### DIFF
--- a/frontend/src/booking/calendar.vue
+++ b/frontend/src/booking/calendar.vue
@@ -284,7 +284,7 @@
         this.$refs.bookingcal.fireMethod('updateEvent', event)
       },
       eventRender(event, el, view) {
-        el.css('width', '85%')
+        el.css('max-width', '85%')
         if (event.exam && view.name === 'listYear') {
           el.find('td.fc-list-item-title.fc-widget-content').html(
           `<div style="display: flex; justify-content: center; width: 100%;">


### PR DESCRIPTION
Client testing found that the booking calendar events, when stacked on top of each other, were bleeding into other columns. This was fixed by changing the width css property to max-width of 85%.