### PR TITLE
Fixed issue with hardcoded exam_type_name for Monthly Session Exams

### DIFF
--- a/frontend/src/booking/booking-modal.vue
+++ b/frontend/src/booking/booking-modal.vue
@@ -345,7 +345,7 @@
           this.selectedOption = 'unassigned'
           return
         }
-        if (this.exam.exam_type.exam_type_name.includes('Challenger')) {
+        if (this.exam.exam_type.exam_type_name === 'Monthly Session Exam') {
           this.selectedOption = 'unassigned'
           return
         }

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -302,7 +302,7 @@
       },
       examType() {
         if (this.examRow && this.examRow.exam_type) {
-          if (this.exam.exam_type.exam_type_name.includes('Challenger')) {
+          if (this.exam.exam_type.exam_type_name === 'Monthly Session Exam') {
             return 'challenger'
           }
           if (this.exam.exam_type.exam_type_name.includes('Group')) {

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -222,7 +222,7 @@
             </template>
             <template v-if="!row.item.exam_returned_date">
               <template v-if="officeFilter == userOffice || officeFilter == 'default'">
-                <template v-if="row.item.exam_type.exam_type_name.includes('Challenger')">
+                <template v-if="row.item.exam_type.exam_type_name === 'Monthly Session Exam' ">
                   <template v-if="row.item.offsite_location">
                     <b-dropdown-item size="sm"
                                      v-if="row.item.offsite_location"
@@ -499,7 +499,7 @@
         this.toggleEditGroupBookingModal(true)
       },
       filterByGroup(ex) {
-        if (ex.exam_type.exam_type_name.includes('Challenger') || ex.exam_type.exam_type_name.includes('Group')) {
+        if (ex.exam_type.exam_type_name === 'Monthly Session Exam' || ex.exam_type.exam_type_name.includes('Group')) {
           return true
         }
         if (ex.number_of_students && parseInt(ex.number_of_students) > 1) {
@@ -510,10 +510,10 @@
       filterByScheduled(ex) {
         if (ex.exam_received_date) {
           if (ex.booking && ( ex.booking.invigilator_id || ex.booking.sbc_staff_invigilated )) {
-            if (!ex.exam_type.exam_type_name.includes('Challenger')) {
+            if (ex.exam_type.exam_type_name !== 'Monthly Session Exam') {
               return true
             }
-            if (ex.exam_type.exam_type_name.includes('Challenger')) {
+            if (ex.exam_type.exam_type_name === 'Monthly Session Exam') {
               if (ex.number_of_students && ex.event_id) {
                 return true
               }


### PR DESCRIPTION
These had previously been called 'challenger' exams and the front-end had not been 100% changed over.
Now all instances where exam_type_name is searched refer to 'Monthly Session Exam'