### PR TITLE
Modified EditGroupBookingModal to Support Booking Other Exams Offsite

### DIFF
--- a/frontend/src/exams/add-exam-form-components.js
+++ b/frontend/src/exams/add-exam-form-components.js
@@ -221,6 +221,16 @@ export const ExamReceivedQuestion = Vue.component('exam-received-question', {
   },
   methods: {
     ...mapMutations(['captureExamDetail', 'toggleIndividualCaptureTabRadio']),
+    unsetDate(e) {
+      if (!e && this.modalSetup === 'individual') {
+        this.handleInput({
+          target: {
+            name: 'exam_received_date',
+            value: null
+          }
+        })
+      }
+    },
     preSetDate() {
       if (this.modalSetup === 'other' || this.modalSetup === 'pesticide') {
         this.handleInput({
@@ -249,6 +259,7 @@ export const ExamReceivedQuestion = Vue.component('exam-received-question', {
           </label><br>
           <b-form-radio-group v-model="showRadio"
                               @input="preSetDate()"
+                              @change="unsetDate"
                               autocomplete="off"
                               :options="['other', 'pesticide'].includes(modalSetup) ? otherOptions : options"/>
         </b-form-group>

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -167,8 +167,11 @@
                 <div class="q-id-grid-col">
                   <div>Type:</div>
                   <div v-if="isITAGropOrSingleExam(exam)"
-                       :style="{color: exam.exam_type.exam_color}">{{ exam.exam_type.exam_type_name }}</div>
-                  <div v-else>{{ exam.exam_type.exam_type_name }}</div>
+                       :style="{ backgroundColor: exam.exam_type.exam_color,
+                                 height: 10+'px',
+                                 margin: '4px 0px 0px 0px',
+                                 width: 10+'px', }"></div>
+                  <div>{{ exam.exam_type.exam_type_name }}</div>
                 </div>
                 <div class="q-id-grid-col">
                   <div>Method:</div>
@@ -299,15 +302,19 @@
       },
       examType() {
         if (this.exam && this.exam.exam_type) {
-          if (this.exam.exam_type.exam_type_name === 'Monthly Session Exam') {
+          let { exam_type } = this.exam
+
+          if (exam_type.exam_type_name === 'Monthly Session Exam') {
             return 'challenger'
-          } else if (this.exam.exam_type.group_exam_ind) {
+          }
+          if (exam_type.group_exam_ind) {
             return 'group'
-          } else {
+          }
+          if (exam_type.ita_ind) {
             return 'individual'
           }
+          return 'other'
         }
-        return 'other'
       },
       examTypeDropClass() {
         if (!this.clickedMenu) {

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -6,7 +6,7 @@
            hide-footer
            size="md">
     <div v-if="showModal">
-      <span class="q-modal-header">Edit Group Exam Booking</span>
+      <span class="q-modal-header">Edit {{ titleText }} Exam Booking</span>
       <b-form autocomplete="off">
         <b-form-row>
           <b-col class="mb-2">
@@ -38,37 +38,31 @@
           </b-col>
         </b-form-row>
         <b-form-row>
-          <b-col cols="6" v-if="is_liaison_designate || role_code === 'GA'">
+          <b-col cols="6">
             <b-form-group>
               <label>Exam Date</label><br>
               <DatePicker v-model="date"
+                          style="color: black"
+                          :disabled="fieldDisabled"
                           name="date"
-                          class="w-100"
+                          input-class="custom-disabled-fields form-control"
+                          class="w-100 date-time-fields"
                           @input="checkDate"
-                          lang="en"></DatePicker>
+                          lang="en">
+              </DatePicker>
             </b-form-group>
           </b-col>
-          <b-col cols="6" v-if="role_code !== 'GA' && !is_liaison_designate">
-            <b-form-group>
-              <label>Exam Time</label><br>
-              <b-input disabled :value="formatTime(actionedExam.booking.start_time)" />
-            </b-form-group>
-          </b-col>
-          <b-col cols="6" v-if="role_code !== 'GA' && !is_liaison_designate">
-            <b-form-group>
-              <label>Exam Date</label><br>
-              <b-input disabled :value="formatDate(actionedExam.booking.start_time)" />
-            </b-form-group>
-          </b-col>
-          <b-col cols="6" v-if="is_liaison_designate || role_code === 'GA'">
+
+          <b-col cols="6">
             <b-form-group>
               <label>Exam Time</label><br>
               <DatePicker v-model="time"
                           class="w-100"
+                          :disabled="fieldDisabled"
                           :time-picker-options="{ start: '8:00', step: '00:30', end: '17:00' }"
                           lang="en"
                           format="h:mm a"
-                          confirm
+                          input-class="custom-disabled-fields form-control"
                           name="time"
                           @input="checkTime"
                           type="time">
@@ -86,8 +80,9 @@
             <b-form-group>
               <label>Location</label><br>
               <b-textarea v-model="offsite_location"
-                          :disabled="role_code !== 'GA' && !is_liaison_designate"
-                          class="mb-0"
+                          :disabled="fieldDisabled"
+                          style="color: #525252"
+                          class="mb-0 custom-disabled-fields"
                           :rows="2"
                           name="offsite_location"
                           @input.native="checkInput" />
@@ -155,11 +150,44 @@
         invigilators: 'invigilators',
         user: 'user',
       }),
+      titleText() {
+        switch (this.examType) {
+          case 'group':
+            return 'Group'
+          case 'challenger':
+            return 'Monthly Session'
+          default:
+            return 'Other'
+        }
+      },
       editedTimezone() {
         if (this.actionedExam && this.actionedExam.booking) {
           return this.actionedExam.booking.office.timezone.timezone_name
         }
         return ''
+      },
+      examType() {
+        if (this.actionedExam && this.actionedExam.exam_type) {
+          let { exam_type } = this.actionedExam
+
+          if (exam_type.exam_type_name === 'Monthly Session Exam') {
+            return 'challenger'
+          }
+          if (exam_type.group_exam_ind) {
+            return 'group'
+          }
+          if (exam_type.ita_ind) {
+            return 'individual'
+          }
+          return 'other'
+        }
+        return ''
+      },
+      fieldDisabled() {
+        if ((this.role_code !== 'GA' && !this.is_liaison_designate) && this.examType != 'other') {
+          return true
+        }
+        return false
       },
       modalVisible: {
         get() {
@@ -374,7 +402,7 @@
             this.invigilator_id = tempItem.booking.invigilator_id
           }
         }
-        this.offsite_location = tempItem.offsite_location
+        tempItem.offsite_location === '_offsite' ? this.offsite_location = '' : tempItem.offsite_location
         this.editedFields = []
         this.itemCopy = tempItem
       },
@@ -398,5 +426,8 @@
   .id-grid-1st-col {
     grid-column: 1 / span 2;
     margin-right: 20px;
+  }
+  .custom-disabled-fields {
+    color: #525252 !important;
   }
 </style>


### PR DESCRIPTION
Changed guards to allow CSRs as well as GA/Designates to edit all fields for the "other" exam type and removed the special case fields being displayed in favour of just showing the date and time pickers but with conditions on disabled prop.