### PR TITLE
Exam Inventory Sorting

### DIFF
--- a/api/app/resources/bookings/exam/exam_list.py
+++ b/api/app/resources/bookings/exam/exam_list.py
@@ -15,7 +15,7 @@ limitations under the License.'''
 import logging
 from flask import g, request
 from flask_restplus import Resource
-from sqlalchemy import exc, or_
+from sqlalchemy import exc, or_, desc
 from app.models.bookings import Exam
 from app.models.theq import CSR
 from app.schemas.bookings import ExamSchema
@@ -38,13 +38,15 @@ class ExamList(Resource):
             if csr.liaison_designate == 1:
                 exams = Exam.query.filter(Exam.deleted_date.is_(None))\
                                   .filter(or_(Exam.exam_returned_date.is_(None),
-                                              Exam.exam_returned_date > ninety_day_filter))
+                                              Exam.exam_returned_date > ninety_day_filter))\
+                                  .order_by(desc(Exam.exam_id))
 
             else:
                 exams = Exam.query.filter(Exam.deleted_date.is_(None))\
                                   .filter_by(office_id=csr.office_id)\
                                   .filter(or_(Exam.exam_returned_date.is_(None),
-                                              Exam.exam_returned_date > ninety_day_filter))
+                                              Exam.exam_returned_date > ninety_day_filter))\
+                                  .order_by(desc(Exam.exam_id))
 
             search_kwargs = {}
 


### PR DESCRIPTION
Client testing found that the exam inventory table needed to be sorted from newest to oldest. This was accomplished by placing an order_by on the object generated in the exam-list endpoint to DESC sort based on the exam_id column.