### PR TITLE
Fix IE Issue: EditExamModal datepicker does not update on change

### DIFF
--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -251,7 +251,11 @@
           { value: false, text: 'No' },
           { value: true, text: 'Yes' },
         ],
-        fields: {},
+        fields: {
+          exam_received_date: null,
+          notes: null,
+          event_id: null,
+        },
         message: '',
         methodOptions: [
           { text: 'paper', value: 'paper'},


### PR DESCRIPTION
Component local state storing values in object as keys which were initialized if they had preset values but exam_received_date is not set in this case and so the v-model was creating the key non-reactively.  Added exam_received_date: null to the predifined component local data to ensure reactivity.