### PR TITLE
Fix Showstopper: Required Fields in Appointment Booking Modal

### DIFF
--- a/frontend/src/add-citizen/add-citizen.vue
+++ b/frontend/src/add-citizen/add-citizen.vue
@@ -1,6 +1,7 @@
 <template>
   <b-modal :visible="showAddModal"
            :size="simplified ? 'md' : 'lg'"
+           :key="Math.random()"
            hide-header
            hide-footer
            no-close-on-backdrop


### PR DESCRIPTION
Presently the backend rejects a request to submit a Appointment when the appointment does not include contact_information field.  This is contrary to what was discussed prior to building and has been corrected.