### PR TITLE
Showstopper Fix: Add Citizen Modal: Scroll Memory

### DIFF
--- a/frontend/src/add-citizen/add-citizen.vue
+++ b/frontend/src/add-citizen/add-citizen.vue
@@ -1,5 +1,6 @@
 <template>
   <b-modal :visible="showAddModal"
+           :key="Math.random()"
            :size="simplified ? 'md' : 'lg'"
            hide-header
            hide-footer


### PR DESCRIPTION
Stopped modal from retaining scroll position  unexpectedly.