### PR TITLE
Fix Showstopper:  Add Citizen Modal Usage of :key

### DIFF
--- a/frontend/src/add-citizen/add-citizen.vue
+++ b/frontend/src/add-citizen/add-citizen.vue
@@ -1,6 +1,6 @@
 <template>
   <b-modal :visible="showAddModal"
-           :key="Math.random()"
+           v-if="showAddModal"
            :size="simplified ? 'md' : 'lg'"
            hide-header
            hide-footer


### PR DESCRIPTION
Fixed scroll position memory by using v-if instead of using :key='math.random()' as this resulted in other unexpected issues.