### PR TITLE
Fix Exam Inventory Table Filters

### DIFF
--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -646,8 +646,8 @@
           if (!item.number_of_students) {
             output.push('Number of Students')
           }
-          if (!item.session_number) {
-            output.push('Session Number')
+          if (!item.event_id) {
+            output.push('Event ID')
           }
         }
         if (item.booking && !item.booking.invigilator_id && !item.booking.sbc_staff_invigilated) {


### PR DESCRIPTION
Challenger Exam Filter Criteria refer to session_number instead of event_id in error.  Re-worded and fixed.