### PR TITLE
Fix various showstoppers

### DIFF
--- a/api/app/schemas/bookings/appointment_schema.py
+++ b/api/app/schemas/bookings/appointment_schema.py
@@ -31,6 +31,6 @@ class AppointmentSchema(ma.ModelSchema):
     start_time = fields.DateTime()
     end_time = fields.DateTime()
     checked_in_time = fields.DateTime()
-    comments = fields.String()
+    comments = fields.String(allow_none=True)
     citizen_name = fields.String()
-    contact_information = fields.String()
+    contact_information = fields.String(allow_none=True)

--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -2,148 +2,154 @@
 
 <template>
   <div id="serveModal" class="serve-modal">
+     v-if="showServeCitizenSpinner" />
     <div class="serve-modal-content">
-      <b-alert :show="this.serveModalAlert != ''"
-                style="h-align: center"
-                variant="warning">{{this.serveModalAlert}}</b-alert>
-      <div class="modal_header" v-dragged="onDrag">
-        <div>
-          <h4 style="font-weight:900; color:#6e6e6e">
-            {{ simplifiedModal ? 'Exams Time Tracking' : 'Serve Citizen' }}</h4>
-        </div>
-        <div>
-          <button
-                    class="btn btn-link"
-                    @click="toggleFeedback">Feedback</button>
-          <button
-                    class="btn btn-link"
-                    style="margin-left: 20px"
-                    @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
-        </div>
-      </div>
-      <template v-if="!simplifiedModal">
-        <b-container id="serve-citizen-modal-top" fluid v-if="!minimizeWindow">
-          <b-row no-gutters class="p-2">
-            <b-col col cols="4">
-              <div><h6>Ticket #: <strong>{{citizen.ticket_number}}</strong></h6></div>
-              <div><h6>Channel: <strong>{{channel.channel_name}}</strong></h6></div>
-              <div><h6>Created At: <strong>{{formatTime(citizen.start_time)}}</strong></h6></div>
-            </b-col>
-            <b-col cols="auto" class="ml-3 mr-2">
-              <h6>Comments:</h6>
-            </b-col>
-            <b-col col cols="*" style="text-align: left" class="pr-2">
-              <div>
-                <b-textarea id="serve_comment_textarea"
-                            v-model="comments"
-                            :rows="4"
-                            size="sm" />
-              </div>
-            </b-col>
-          </b-row>
-        </b-container>
-        <b-container id="serve-top-buttons-container" v-if="!minimizeWindow">
-          <div>
-            <b-button @click="clickServiceBeginService"
-                    v-if="reception"
-                    :disabled="serviceBegun===true || performingAction"
-                    v-bind:class="buttonStyle"
-                    style="margin-right:8px; opacity:1"
-                    id="serve-citizen-begin-service-button">Begin Service</b-button>
-            <b-button @click="clickReturnToQueue"
-                    v-if="reception"
-                    :disabled="performingAction"
-                    class="btn serve-btn"
-                    id="serve-citizen-return-to-queue-button">Return to Queue</b-button>
-          </div>
-          <div>
-            <b-button @click="clickCitizenLeft"
-                    :disabled="performingAction"
-                    class="btn-danger serve-btn"
-                    v-if="reception"
-                    id="serve-citizen-citizen-left-button">Citizen Left</b-button>
-          </div>
-        </b-container>
+      <template v-if="showServeCitizenSpinner">
+        <div class="q-loader" />
       </template>
-      <ServeCitizenTable v-if="!minimizeWindow"/>
-      <template v-if="!simplifiedModal && !minimizeWindow">
-        <b-container fluid
-                     id="serve-light-inner-container"
-                     class="pt-3 pb-2">
-          <b-row no-gutters>
-            <b-col cols="7" />
-              <div class="q-w100-flex-fe">
-                  <b-form-checkbox v-model="quick"
-                                   value="1"
-                                   unchecked-value="0"
-                                   v-if="reception"
-                                   class="quick-checkbox mt-1"
-                                   style="color:white; margin-right: 8px;">
-                    <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
-                    <span class="quick-span" v-if="quick"></span> <!-- For puppeteer testing to see if quick is selected -->
-                  </b-form-checkbox>
-
-                <select id="priority-selection"
-                        class="custom-select px-1"
-                        v-model="priority_selection"
-                        style="margin-right:8px;">
-                  <option value=1>High Priority</option>
-                  <option value=2>Default Priority</option>
-                  <option value=3>Low Priority</option>
-                </select>
-                <b-button class="btn-primary serve-btn"
-                          @click="clickAddService"
-                          :disabled="serviceBegun===false || performingAction">Add Next Service</b-button>
-              </div>
-            <b-col cols="2" />
-          </b-row>
-        </b-container>
-        <div v-if="!minimizeWindow">
-          <b-container fluid
-                       id="serve-citizen-modal-footer">
-                  <div style="display:flex; flex-direction:column; margin-left:10px;">
-                      <b-form-checkbox v-model="accurate_time_ind"
-                                                      v-if="serviceBegun===true"
-                                                      value="0"
-                                                      style="color:white; margin:0 0 8px;"
-                                                      unchecked-value="1">
-                                      <span  style="font: 400 16px Myriad-Pro;">Inaccurate Time</span>
-                                      </b-form-checkbox>
-                      <b-button @click="clickServiceFinish"
-                              :disabled="serviceBegun===false || performingAction"
-                              class="btn-success serve-btn"
-                              id="serve-citizen-finish-button">Finish</b-button>
-                  </div>
-                <b-button @click="clickHold"
-                          :disabled="serviceBegun===false || performingAction"
-                          class="btn-warning serve-btn"
-                          id="serve-citizen-place-on-hold-button">Place on Hold</b-button>
+      <template v-else>
+        <b-alert :show="this.serveModalAlert != ''"
+                  style="h-align: center"
+                  variant="warning">{{this.serveModalAlert}}</b-alert>
+        <div class="modal_header" v-dragged="onDrag">
+          <div>
+            <h4 style="font-weight:900; color:#6e6e6e">
+              {{ simplifiedModal ? 'Exams Time Tracking' : 'Serve Citizen' }}</h4>
+          </div>
+          <div>
+            <button
+                      class="btn btn-link"
+                      @click="toggleFeedback">Feedback</button>
+            <button
+                      class="btn btn-link"
+                      style="margin-left: 20px"
+                      @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
+          </div>
+        </div>
+        <template v-if="!simplifiedModal">
+          <b-container id="serve-citizen-modal-top" fluid v-if="!minimizeWindow">
+            <b-row no-gutters class="p-2">
+              <b-col col cols="4">
+                <div><h6>Ticket #: <strong>{{citizen.ticket_number}}</strong></h6></div>
+                <div><h6>Channel: <strong>{{channel.channel_name}}</strong></h6></div>
+                <div><h6>Created At: <strong>{{formatTime(citizen.start_time)}}</strong></h6></div>
+              </b-col>
+              <b-col cols="auto" class="ml-3 mr-2">
+                <h6>Comments:</h6>
+              </b-col>
+              <b-col col cols="*" style="text-align: left" class="pr-2">
+                <div>
+                  <b-textarea id="serve_comment_textarea"
+                              v-model="comments"
+                              :rows="4"
+                              size="sm" />
+                </div>
+              </b-col>
+            </b-row>
           </b-container>
-        </div>
-      </template>
-      <template v-if="simplifiedModal && !minimizeWindow">
-        <b-container class="serve-citizen-modal-footer" fluid>
-          <b-row no-gutters class="w-100" align-h="end">
-            <b-col cols="auto">
-              <b-button class="btn-primary serve-btn"
-                        @click="clickAddService">Add Next Service</b-button>
-            </b-col>
-          </b-row>
-          <b-row no-gutters
-                 class="mt-3"
-                 align-h="end">
-            <b-col cols="auto">
-              <b-button @click="clickSimplifiedFinish"
-                        style="width: 100px;"
-                         class="btn-warning serve-btn"
-                         id="serve-citizen-finish-button">Finish</b-button>
-              <b-button @click="clickContinue"
-                        style="width: 100px;"
-                        class="btn-success serve-btn ml-2"
-                        id="serve-citizen-finish-button">Continue</b-button>
-            </b-col>
-          </b-row>
-        </b-container>
+          <b-container id="serve-top-buttons-container" v-if="!minimizeWindow">
+            <div>
+              <b-button @click="clickServiceBeginService"
+                      v-if="reception"
+                      :disabled="serviceBegun===true || performingAction"
+                      v-bind:class="buttonStyle"
+                      style="margin-right:8px; opacity:1"
+                      id="serve-citizen-begin-service-button">Begin Service</b-button>
+              <b-button @click="clickReturnToQueue"
+                      v-if="reception"
+                      :disabled="performingAction"
+                      class="btn serve-btn"
+                      id="serve-citizen-return-to-queue-button">Return to Queue</b-button>
+            </div>
+            <div>
+              <b-button @click="clickCitizenLeft"
+                      :disabled="performingAction"
+                      class="btn-danger serve-btn"
+                      v-if="reception"
+                      id="serve-citizen-citizen-left-button">Citizen Left</b-button>
+            </div>
+          </b-container>
+        </template>
+        <ServeCitizenTable v-if="!minimizeWindow"/>
+        <template v-if="!simplifiedModal && !minimizeWindow">
+          <b-container fluid
+                       id="serve-light-inner-container"
+                       class="pt-3 pb-2">
+            <b-row no-gutters>
+              <b-col cols="7" />
+                <div class="q-w100-flex-fe">
+                    <b-form-checkbox v-model="quick"
+                                     value="1"
+                                     unchecked-value="0"
+                                     v-if="reception"
+                                     class="quick-checkbox mt-1"
+                                     style="color:white; margin-right: 8px;">
+                      <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
+                      <span class="quick-span" v-if="quick"></span> <!-- For puppeteer testing to see if quick is selected -->
+                    </b-form-checkbox>
+
+                  <select id="priority-selection"
+                          class="custom-select px-1"
+                          v-model="priority_selection"
+                          style="margin-right:8px;">
+                    <option value=1>High Priority</option>
+                    <option value=2>Default Priority</option>
+                    <option value=3>Low Priority</option>
+                  </select>
+                  <b-button class="btn-primary serve-btn"
+                            @click="clickAddService"
+                            :disabled="serviceBegun===false || performingAction">Add Next Service</b-button>
+                </div>
+              <b-col cols="2" />
+            </b-row>
+          </b-container>
+          <div v-if="!minimizeWindow">
+            <b-container fluid
+                         id="serve-citizen-modal-footer">
+                    <div style="display:flex; flex-direction:column; margin-left:10px;">
+                        <b-form-checkbox v-model="accurate_time_ind"
+                                                        v-if="serviceBegun===true"
+                                                        value="0"
+                                                        style="color:white; margin:0 0 8px;"
+                                                        unchecked-value="1">
+                                        <span  style="font: 400 16px Myriad-Pro;">Inaccurate Time</span>
+                                        </b-form-checkbox>
+                        <b-button @click="clickServiceFinish"
+                                :disabled="serviceBegun===false || performingAction"
+                                class="btn-success serve-btn"
+                                id="serve-citizen-finish-button">Finish</b-button>
+                    </div>
+                  <b-button @click="clickHold"
+                            :disabled="serviceBegun===false || performingAction"
+                            class="btn-warning serve-btn"
+                            id="serve-citizen-place-on-hold-button">Place on Hold</b-button>
+            </b-container>
+          </div>
+        </template>
+        <template v-if="simplifiedModal && !minimizeWindow">
+          <b-container class="serve-citizen-modal-footer" fluid>
+            <b-row no-gutters class="w-100" align-h="end">
+              <b-col cols="auto">
+                <b-button class="btn-primary serve-btn"
+                          @click="clickAddService">Add Next Service</b-button>
+              </b-col>
+            </b-row>
+            <b-row no-gutters
+                   class="mt-3"
+                   align-h="end">
+              <b-col cols="auto">
+                <b-button @click="clickSimplifiedFinish"
+                          style="width: 100px;"
+                           class="btn-warning serve-btn"
+                           id="serve-citizen-finish-button">Finish</b-button>
+                <b-button @click="clickContinue"
+                          style="width: 100px;"
+                          class="btn-success serve-btn ml-2"
+                          id="serve-citizen-finish-button">Continue</b-button>
+              </b-col>
+            </b-row>
+          </b-container>
+        </template>
       </template>
     </div>
   </div>
@@ -174,8 +180,11 @@ export default {
   },
   updated() {
     if (!this.citizen && this.citizen.ticket_number === "") {
+      this.$store.commit('toggleServeCitizenSpinner', true)
       console.log("Screen All Citizens")
-      this.screenAllCitizens(this.$route)
+      this.screenAllCitizens(this.$route).then(() => {
+        this.$store.commit('toggleServeCitizenSpinner', false)
+      })
     }
     setTimeout( () => {
       if (!this.citizen && this.citizen.ticket_number === "") {
@@ -187,6 +196,7 @@ export default {
     ...mapState([
       'performingAction',
       'showServiceModal',
+      'showServeCitizenSpinner',
       'serviceBegun',
       'serviceModalForm',
       'serveModalAlert'

--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -2,7 +2,6 @@
 
 <template>
   <div id="serveModal" class="serve-modal">
-     v-if="showServeCitizenSpinner" />
     <div class="serve-modal-content">
       <template v-if="showServeCitizenSpinner">
         <div class="q-loader" />

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -146,6 +146,7 @@ export const store = new Vuex.Store({
     showFeedbackModal: false,
     showGAScreenModal: false,
     showSelectInvigilatorModal: false,
+    showServeCitizenSpinner: false,
     showOtherBookingModal: false,
     showResponseModal: false,
     showReturnExamModal: false,
@@ -1046,6 +1047,7 @@ export const store = new Vuex.Store({
     },
 
     clickDashTableRow(context, citizen_id) {
+      context.commit('toggleServeCitizenSpinner', true)
       context.commit('setPerformingAction', true)
 
       context.dispatch('postInvite', citizen_id).then( () => {
@@ -1450,7 +1452,6 @@ export const store = new Vuex.Store({
             if (error.response.status === 400) {
               context.commit('setMainAlert', error.response.data.message)
             }
-
             reject(error)
           })
         })
@@ -1901,6 +1902,7 @@ export const store = new Vuex.Store({
           }
         }
       }
+      context.commit('toggleServeCitizenSpinner', false)
     },
     
     setAddModalData(context) {
@@ -2405,5 +2407,7 @@ export const store = new Vuex.Store({
     setAppointmentsStateInfo: (state, payload) => state.appointmentsStateInfo = payload,
   
     clearAddExamModalFromCalendarStatus: state => Vue.delete(state.addExamModal, 'fromCalendar'),
+  
+    toggleServeCitizenSpinner: (state, payload) => state.showServeCitizenSpinner = payload,
   }
 })


### PR DESCRIPTION
Fix Appointment Booking Modal: Error 422 w/o Contact Info
Contact info did not have allow-none flag in schema.  Added it to comments as well.

+

Fix Showstopper:  Delay when loading Serve Citizen in the Q
Added a spinner to display while browser is parsing citizen data for display in modal to prevent invalid data messages from briefly appearing to user.