### PR TITLE
Financial Reporting - Filtering Offices

### DIFF
--- a/api/app/resources/bookings/exam/exam_export_list.py
+++ b/api/app/resources/bookings/exam/exam_export_list.py
@@ -37,7 +37,10 @@ class ExamList(Resource):
     def get(self):
 
         try:
+
             csr = CSR.find_by_username(g.oidc_token_info['username'])
+
+            is_designate = csr.finance_designate
 
             start_param = request.args.get("start_date")
             end_param = request.args.get("end_date")
@@ -59,14 +62,16 @@ class ExamList(Resource):
 
             end_date = self.timezone.localize(end_date)
 
-            exams = Exam.query.filter_by(office_id=csr.office_id) \
-                              .join(Booking, Exam.booking_id == Booking.booking_id) \
+            exams = Exam.query.join(Booking, Exam.booking_id == Booking.booking_id) \
                               .filter(Booking.start_time >= start_date) \
                               .filter(Booking.start_time < end_date) \
                               .join(Invigilator, Booking.invigilator_id == Invigilator.invigilator_id, isouter=True) \
                               .join(Room, Booking.room_id == Room.room_id, isouter=True) \
                               .join(Office, Booking.office_id == Office.office_id) \
                               .join(ExamType, Exam.exam_type_id == ExamType.exam_type_id)
+
+            if not is_designate:
+                exams = exams.filter(Booking.office_id == csr.office_id)
 
             if exam_type == 'ita':
                 exams = exams.filter(ExamType.ita_ind == 1)


### PR DESCRIPTION
Clients asked that if a user is a financial reporting designate to return ALL exams when the query for reporting is submited. Otherwise the exams returned to the user are filtered based upon the users office.