### PR TITLE
Fix Serve Citizen Modal Loading Spinner

### DIFF
--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -16,13 +16,11 @@
               {{ simplifiedModal ? 'Exams Time Tracking' : 'Serve Citizen' }}</h4>
           </div>
           <div>
-            <button
-                      class="btn btn-link"
-                      @click="toggleFeedback">Feedback</button>
-            <button
-                      class="btn btn-link"
-                      style="margin-left: 20px"
-                      @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
+            <button class="btn btn-link"
+                    @click="toggleFeedback">Feedback</button>
+            <button class="btn btn-link"
+                    style="margin-left: 20px"
+                    @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
           </div>
         </div>
         <template v-if="!simplifiedModal">

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -968,6 +968,7 @@ export const store = new Vuex.Store({
     },
   
     clickBeginService(context, payload) {
+      context.commit('toggleServeCitizenSpinner', true)
       let { citizen_id } = context.getters.form_data.citizen
       context.commit('setPerformingAction', true)
     
@@ -1132,6 +1133,7 @@ export const store = new Vuex.Store({
     },
 
     clickInvite(context) {
+      context.commit('toggleServeCitizenSpinner', true)
       context.commit('setPerformingAction', true)
 
       context.dispatch('postInvite', 'next').then(() => {
@@ -1235,6 +1237,7 @@ export const store = new Vuex.Store({
     },
 
     clickRowHoldQueue(context, citizen_id) {
+      context.commit('toggleServeCitizenSpinner', true)
       context.commit('setPerformingAction', true)
 
       context.dispatch('postBeginService', citizen_id).then( () => {
@@ -1245,7 +1248,7 @@ export const store = new Vuex.Store({
         context.commit('setPerformingAction', false)
       })
     },
-
+    
     toggleBegunStatus({commit}) {
       commit('toggleBegunStatus', payload)
     },
@@ -2409,6 +2412,8 @@ export const store = new Vuex.Store({
   
     clearAddExamModalFromCalendarStatus: state => Vue.delete(state.addExamModal, 'fromCalendar'),
   
-    toggleServeCitizenSpinner: (state, payload) => state.showServeCitizenSpinner = payload,
+    toggleServeCitizenSpinner(state, payload) {
+      state.showServeCitizenSpinner = payload
+    },
   }
 })


### PR DESCRIPTION
Previously added trigger to show the spinner when clicking on a citizen from the queue table but failed to consider the scenarios of clicking on a citizen in the hold table or directly from the Add Citizen Modal.  Added triggers for the other ways to launch the modal.