### PR TITLE
Group Exam Notifications - SBC Staff

### DIFF
--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -89,7 +89,8 @@ class CsrSelf(Resource):
                 .join(ExamType, Exam.exam_type_id == ExamType.exam_type_id) \
                 .filter(ExamType.group_exam_ind == 1) \
                 .join(Booking, Exam.booking_id == Booking.booking_id) \
-                .filter(Booking.invigilator_id.is_(None)).count()
+                .filter(Booking.invigilator_id.is_(None))\
+                .filter(Booking.sbc_staff_invigilated == 0).count()
 
             result = self.csr_schema.dump(csr)
             active_citizens = self.citizen_schema.dump(active_citizens)


### PR DESCRIPTION
Clients noticed after production release that group exams were causing the notification banner to show if SBC Staff were selected as invigilators. This condition met the requirements of not having to notify staff about exams, and such was fixed by adding a filter the group exam object in the csrs/me endpoint that only counted exams with booking.sbc_staff_invigilated == 0. This was tested by creating a group exam object, then creating a booking for this exams without an inviglator and making sure the notification would present itself on refresh. Then, altering the booking to have SBC staff invigilate the booking, refreshing the page to make sure no notification was present. Finally, the booking was altered to have an actual invigilator present for the booking, and refreshing the page to make sure that the notification banner was not present.