### PR TITLE
Fix to Allow Office Mgr to Edit Group/Session Exam Details + others

### DIFF
--- a/frontend/src/exams/return-exam-form-modal.vue
+++ b/frontend/src/exams/return-exam-form-modal.vue
@@ -153,7 +153,7 @@
     },
     methods: {
       ...mapActions(['putExamInfo', 'getExams', ]),
-      ...mapMutations(['toggleReturnExamModal', 'setEditExamSuccess', 'setEditExamFailure',  ]),
+      ...mapMutations(['toggleReturnExamModal', 'setEditExamFailure',  ]),
       handleReturnedStatus(value) {
         if (value) {
           if (!this.exam_returned_date) {

--- a/frontend/src/exams/success-exam-alert.vue
+++ b/frontend/src/exams/success-exam-alert.vue
@@ -19,7 +19,7 @@ limitations under the License.*/
       dismissible
       v-model="countdown"
       @dismissed="setEditExamSuccess"
-       style="h-align: center; font-size:1rem; border-radius: 0px;">
+      style="h-align: center; font-size:1rem; border-radius: 0px;">
       Success!
     </b-alert>
   </div>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1622,7 +1622,7 @@ export const store = new Vuex.Store({
         let url = `/exams/${id}/`
         Axios(context).put(url, payload).then( () =>{
           context.dispatch('getExams').then( () => {
-            context.commit('setEditExamSuccess', 6)
+            context.commit('setEditExamSuccess', 3)
             resolve()
           })
         })


### PR DESCRIPTION
Logic controlling access to the full version of the Edit Exam Modal did not consider the ita_designate key.  Office Manager previously saw only the fields-limited CSR version.   Changed so that office mgr has same access as GA role.  Also fixed:
    -liaison_designate were unable to edit office of pesticide exams or delete exams they add in error
    -the exam_type field of the EditExamModal was listing exam_types which did not make sense. Disabled the ability to switch exam_type on a pesticide exam or challenger exam at all and restricted changing 'other' 'individual ita' and 'group ita' to exam type options of their catagory only.
-adjusted the other field-display and field-disable logic to ensure access to necessary features for office managers
-set the time of the editExamSuccess banner to 3 seconds instead of 6
