### PR TITLE
Return Exam fix: Action Taken Length & Deleted Invigilator Changes

### DIFF
--- a/frontend/src/appointments/appointments.vue
+++ b/frontend/src/appointments/appointments.vue
@@ -57,6 +57,7 @@
     },
     data() {
       return {
+        blockEventSelect: false,
         clickedAppt: null,
         clickedTime: null,
         config: {
@@ -134,6 +135,9 @@
         return null
       },
       eventSelected(event) {
+        if (event.id === '_tempEvent') {
+          return
+        }
         this.clickedAppt = event
         this.highlightEvent(event)
         this.toggleCheckInModal(true)
@@ -157,6 +161,7 @@
         this.$refs.appointments.fireMethod('renderEvent', event)
       },
       selectEvent(event) {
+        this.blockEventSelect = true
         this.unselect()
         let start = event.start.clone()
         let end
@@ -175,6 +180,7 @@
         this.clickedTime = e
         this.setTempEvent(e)
         this.toggleApptBookingModal(true)
+        this.blockEventSelect = false
       },
       clearClickedAppt() {
         this.clickedAppt = null

--- a/frontend/src/exams/add-exam-form-controller.vue
+++ b/frontend/src/exams/add-exam-form-controller.vue
@@ -196,6 +196,11 @@
             messages[key] = ''
             return
           }
+          if (key === 'exam_name' && answer && answer.length > 50) {
+            valid['exam_name'] = false
+            messages['exam_name'] = 'Maximum Field Length Exceeded'
+            return
+          }
           if (key === 'office_id' && answer == null) {
             valid[key] = false
             messages[key] = 'Invalid Office'

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -81,10 +81,16 @@
         <b-form-row>
           <b-col>
             <b-form-group>
-              <label class="mb-0 mt-1">Exam Name</label>
+              <label v-if="!lengthError"
+                     class="mb-0 mt-1">Exam Name</label>
+              <label v-if="lengthError"
+                     style="color: red"
+                     class="mb-0 mt-1">Maximum field length reached.</label>
               <b-form-input id="exam_name"
                             type="text"
                             class="less-10-mb"
+                            @blur="removeError"
+                            v-on:keydown="checkInputLength"
                             v-model="fields.exam_name" />
             </b-form-group>
           </b-col>
@@ -283,7 +289,9 @@
           exam_received_date: null,
           notes: null,
           event_id: null,
+          exam_name: null,
         },
+        lengthError: false,
         message: '',
         methodOptions: [
           { text: 'paper', value: 'paper'},
@@ -467,6 +475,18 @@
       isITAGropOrSingleExam(ex) {
         return ex.exam_type.ita_ind ? true : false
       },
+      checkInputLength(e) {
+        if (e.keyCode == 8 || e.keyCode == 46) {
+          this.removeError()
+          return true
+        }
+        if (this.fields.exam_name && this.fields.exam_name.length >= 50) {
+          this.lengthError = true
+          e.preventDefault()
+          e.stopPropagation()
+          return false
+        }
+      },
       deleteExam() {
         let deleteExamInfo = {}
         if (this.fields.booking_id) {
@@ -523,6 +543,9 @@
         this.office_number = officeNumber
         this.fields.office_id = this.offices.find(office => office.office_number == officeNumber).office_id
       },
+      removeError() {
+        this.lengthError = false
+      },
       reset() {
         Object.keys(this.fields).forEach(key => {
           Vue.set(
@@ -531,6 +554,7 @@
             null
           )
         })
+        this.lengthError = false
         this.clickedMenu = false
         this.message = null
         this.office_number = null

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -101,7 +101,7 @@
           </b-col>
           <b-col cols="2" align-self="start" v-if="is_liaison_designate || role_code === 'GA'">
             <label>Clear Form?</label><br>
-            <b-btn class="w-100 btn-warning" @click="setValues">Reset</b-btn>
+            <b-btn class="w-100 btn-warning" @click="show">Reset</b-btn>
           </b-col>
         </b-form-row>
       </b-form>

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -490,6 +490,9 @@
       filterByScheduled(ex) {
         if (ex.exam_received_date) {
           if (ex.booking && ( ex.booking.invigilator_id || ex.booking.sbc_staff_invigilated )) {
+            if (ex.booking.invigilator && ex.booking.invigilator.deleted) {
+              return false
+            }
             if (ex.exam_type.exam_type_name !== 'Monthly Session Exam') {
               return true
             }
@@ -608,7 +611,7 @@
           if (item.booking.sbc_staff_invigilated) {
             output.Invigilator = 'SBC Staff'
           }
-          if (item.booking.invigilator_id) {
+          if (item.booking.invigilator_id && !item.booking.invigilator.deleted) {
             output.Invigilator = item.booking.invigilator.invigilator_name
           }
           if (item.booking.room_id) {
@@ -695,6 +698,9 @@
           rank: 1,
           style: {fontSize: '1rem', color: 'green'}
         }
+        if (item.booking && item.booking.invigilator && item.booking.invigilator.deleted) {
+          return lifeRing
+        }
         if (item.exam_type.exam_type_name === 'Monthly Session Exam') {
           if (!item.booking) {
             return lifeRing
@@ -741,8 +747,13 @@
             output.push('Event ID')
           }
         }
-        if (item.booking && !item.booking.invigilator_id && !item.booking.sbc_staff_invigilated) {
-          output.push('Assignment of Invigilator')
+        if (item.booking) {
+          if (item.booking.invigilator && item.booking.invigilator.deleted) {
+            output.push('Re-assignment of Invigilator')
+          }
+          if (!item.booking.invigilator_id && !item.booking.sbc_staff_invigilated) {
+            output.push('Assignment of Invigilator')
+          }
         }
         return output
       },

--- a/frontend/src/exams/return-exam-form-modal.vue
+++ b/frontend/src/exams/return-exam-form-modal.vue
@@ -53,11 +53,19 @@
         <b-form-row>
           <b-col>
             <b-form-group class="mb-0 mt-2">
-              <label class="mb-0">Action Taken</label><br>
+              <label v-if="!errorText"
+                     class="mb-0">Action Taken</label>
+              <label v-if="errorText"
+                     style="color: red"
+                     class="mb-0">Maximum field length reached.  Use Notes field if needed.</label>
+              <br>
               <b-form-input v-model="exam_returned_tracking_number"
                             id="action_taken"
-                            placeholder="Include tracking info or exam disposition"
-                            ref="returnactiontaken"/>
+                            placeholder="Include tracking info or disposition"
+                            ref="returnactiontaken"
+                            v-on:keydown="handleActionInput"
+                            @blur="removeError()"
+                            />
             </b-form-group>
           </b-col>
         </b-form-row>
@@ -92,8 +100,9 @@
         returned: false,
         exam_written_ind: true,
         exam_returned_date: null,
+        errorText: false,
         notes: null,
-        exam_returned_tracking_number: null,
+        exam_returned_tracking_number: '',
         returnOptions: [
           { value: false, text: 'Not Returned' },
           { value: true, text: 'Returned' },
@@ -154,6 +163,19 @@
     methods: {
       ...mapActions(['putExamInfo', 'getExams', ]),
       ...mapMutations(['toggleReturnExamModal', 'setEditExamFailure',  ]),
+      handleActionInput(e) {
+        if (e.keyCode == 8 || e.keyCode == 46) {
+          this.removeError()
+          return true
+        }
+        console.log(this.exam_returned_tracking_number.length)
+        if (this.exam_returned_tracking_number && this.exam_returned_tracking_number.length >= 250) {
+          this.errorText = true
+          e.preventDefault()
+          e.stopPropagation()
+          return false
+        }
+      },
       handleReturnedStatus(value) {
         if (value) {
           if (!this.exam_returned_date) {
@@ -184,11 +206,15 @@
       resetModal() {
         this.toggleReturnExamModal(false)
         this.exam = null
+        this.errorText = false
         this.returned = false
         this.exam_returned_date = null
-        this.exam_returned_tracking_number = null
+        this.exam_returned_tracking_number = ''
         this.notes  = null
         this.resetExam()
+      },
+      removeError() {
+        this.errorText = false
       },
       submit() {
         if (this.okButton.title === 'Cancel') {

--- a/frontend/src/exams/return-exam-form-modal.vue
+++ b/frontend/src/exams/return-exam-form-modal.vue
@@ -168,7 +168,6 @@
           this.removeError()
           return true
         }
-        console.log(this.exam_returned_tracking_number.length)
         if (this.exam_returned_tracking_number && this.exam_returned_tracking_number.length >= 250) {
           this.errorText = true
           e.preventDefault()


### PR DESCRIPTION
-Action Taken field now displays an error at the maximum input length and prevents further input
-Adjusted the exam_inventory table to display the life-ring error symbol on any exam assigned to a deleted invigilator and adjusted the filters to show such exams as not ready.
-Changed a call to a method by previous name (which was revised so was null reference) in EditGroupBooking modal