### PR TITLE
Delete Room Admin Warning

### DIFF
--- a/api/app/admin/room.py
+++ b/api/app/admin/room.py
@@ -12,10 +12,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.'''
 
-from app.models.bookings import Room
+from app.models.bookings import Booking, Room
 from .base import Base
+from flask import flash, request
+from flask_admin.babel import gettext
+from flask_admin.model.helpers import get_mdict_item_or_list
 from flask_login import current_user
 from qsystem import db
+from datetime import datetime
+import pytz
 
 
 class RoomConfig(Base):
@@ -29,6 +34,25 @@ class RoomConfig(Base):
             return self.session.query(self.model)
         elif current_user.role.role_code == 'GA':
             return self.session.query(self.model).filter_by(office_id=current_user.office_id)
+
+    def on_model_change(self, form, model, is_created):
+
+        room_id = get_mdict_item_or_list(request.args, 'id')
+        today = datetime.now()
+        today_aware = pytz.utc.localize(today)
+
+        booking_room = Booking.query.filter_by(room_id=room_id)\
+                                    .filter(Booking.start_time > today_aware).count()
+
+        specific_room = Room.query.filter_by(room_id=room_id).first()
+        room_name = specific_room.room_name
+
+        if model.deleted is not None and booking_room > 0:
+            message = "'" + room_name + "' is currently being used for bookings. " \
+                                        "Reschedule bookings that use this room before setting the deleted date."
+            flash(gettext(message), 'warning')
+            model.deleted = None
+            form.deleted.data = None
 
     create_modal = False
     edit_modal = False
@@ -77,6 +101,6 @@ class RoomConfig(Base):
     column_searchable_list = {
         'office.office_name'
     }
-
+    
 
 RoomModelView = RoomConfig(Room, db.session)


### PR DESCRIPTION
Clients required there to be a warning given to admin users if a room is about to have a deleted date applied to it, but it currently being used for bookings in the future. The flask admin on_model_change method was used to detect changes in the deleted date field before submission, and looking at the booking model for instances of such a room being used with start times greater than today (doesn't care about historical instances). If the room isn't in use, the room can be deleted. If the room is in use, and error message propagates telling the user that they were unable to apply the deleted date. Any other changes that the user might make on top of applying a deleted date to a room in use will be saved.