### PR TITLE
Service Ctzn Mnmize Button now hides Modal + Allows Navigation

### DIFF
--- a/frontend/src/add-citizen/form-components/filters.vue
+++ b/frontend/src/add-citizen/form-components/filters.vue
@@ -10,7 +10,7 @@
                  id="simplified_service_input"
                  ></input>
       </b-col>
-      <b-col v-if="!simplified || addModalSetup === 'add_mode'">
+      <b-col>
         <b-select id="add_citizen_catagories_select"
                   style="height: 38px; font-size: .8rem;"
                   :options="categories_options"
@@ -32,12 +32,19 @@
         if (this.$refs && this.$refs.filterref) {
           this.$refs.filterref.focus()
         }
+        if (this.categories && this.categories.length > 0) {
+          if (['/booking', '/exams'].includes(this.$route.path)) {
+            let { service_id } = this.categories .find(cat => cat.service_name === 'Exams')
+            this.updateAddModalForm({type: 'category', value: service_id})
+          }
+        }
       })
     },
     computed: {
       ...mapGetters(['categories_options', 'form_data']),
       ...mapState({
         addModalSetup: 'addModalSetup',
+        categories: state => state.categories,
         suspendFilter: state => state.addModalForm.suspendFilter,
         selectedItem: state => state.addModalForm.selectedItem,
       }),
@@ -66,6 +73,16 @@
       category: {
         get() { return this.form_data.category },
         set(value) { this.updateAddModalForm({type: 'category', value}) }
+      }
+    },
+    watch: {
+      categories(newVal, oldVal) {
+        if (newVal && newVal.length > 0) {
+          if (['/booking', '/exams'].includes(this.$route.path)) {
+            let { service_id } = newVal.find(cat => cat.service_name === 'Exams')
+            this.updateAddModalForm({type: 'category', value: service_id})
+          }
+        }
       }
     },
     methods: {

--- a/frontend/src/add-citizen/form-components/tables.vue
+++ b/frontend/src/add-citizen/form-components/tables.vue
@@ -91,9 +91,6 @@
         ]
       },
       filter(value) {
-        if (this.$route.path === '/exams' || this.$route.path === '/booking') {
-          return `exams ${this.form_data.search}`
-        }
         return this.form_data.search
       },
     },

--- a/frontend/src/layout/nav.vue
+++ b/frontend/src/layout/nav.vue
@@ -18,8 +18,10 @@
   <div style="">
     <div class="dash-button-flex-button-container pb-0 mb-3">
       <!-- SLOT FOR EACH VIEW'S BUTTON CONTROLS-->
-      <div v-if="this.$route.path === '/booking' || this.$route.path === '/exams' ">
-        <b-button :variant="showIcon ? 'warning' : 'primary'"
+      <div style="width: 75px" v-show="$route.path !=='/queue' || showTimeTrackingIcon">
+      <b-button :variant="showIcon.style"
+                  v-if="showIcon.show"
+                  v-show="flashIcon"
                   class="mr-3"
                   @click="clickIcon">
           <font-awesome-icon icon="stopwatch"
@@ -90,11 +92,14 @@
   export default {
     name: 'Nav',
     components: { AddCitizen, ServeCitizen },
+    data() {
+      return {
+        flashIcon: true,
+        showSpacer: false,
+      }
+    },
     computed: {
-      ...mapGetters([
-        'showExams',
-        'showAppointments'
-      ]),
+      ...mapGetters([ 'showExams', 'showAppointments', ]),
       ...mapState([
         'citizenInvited',
         'showServiceModal',
@@ -105,18 +110,21 @@
         'serviceBegun',
         'showGAScreenModal',
         'showServiceModal',
+        'showTimeTrackingIcon',
         'showAddModal',
         'user',
       ]),
       showIcon() {
-        if (this.$route.path !== '/queue' &&
+        if (this.$route.path !== '/queue') {
+          if ( this.serviceModalForm &&
+            this.serviceModalForm.citizen_id &&
             !this.showServiceModal &&
-            !this.showAddModal &&
-            this.serviceModalForm &&
-            this.serviceModalForm.citizen_id) {
-          return true
+            !this.showAddModal ) {
+            return { show: true, style: 'warning' }
+          }
+          return { show: true, style: 'primary'}
         }
-        return false
+        return this.showTimeTrackingIcon ? {show: true, style: 'warning'} : { show: false, style: null}
       },
       isGAorCSR() {
         if (this.user && this.user.role) {
@@ -144,9 +152,31 @@
         return false
       },
     },
+    watch: {
+      showIcon(newV, oldV) {
+        if (this.$route.path === '/queue' && newV.show && !oldV.show) {
+          this.showSpacer = true
+          let k = 4
+          let flash = () => {
+            this.flashIcon = !this.flashIcon
+            k -= 1
+            if (k > 0) {
+              setTimeout(() => { flash()}, 140 )
+            }
+          }
+          flash()
+        }
+      }
+    },
     methods: {
       ...mapActions(['clickGAScreen', 'clickAddCitizen', 'clickRefresh']),
-      ...mapMutations(['toggleFeedbackModal', 'toggleServiceModal']),
+      ...mapMutations(['toggleFeedbackModal', 'toggleServiceModal', 'toggleTrackingIcon', ]),
+      toggleTrackingIcon(bool) {
+        if (!bool) {
+          this.showSpacer = false
+        }
+        this.toggleTimeTrackingIcon(bool)
+      },
       clickFeedback() {
         this.toggleFeedbackModal(true)
       },

--- a/frontend/src/serve-citizen/dash-buttons.vue
+++ b/frontend/src/serve-citizen/dash-buttons.vue
@@ -19,7 +19,7 @@
     <div>
       <b-button class="btn-primary mr-1"
                 @click="invite"
-                :disabled="citizenInvited===true || performingAction || showAdmin"
+                :disabled="citizenInvited || showTimeTrackingIcon || performingAction || showAdmin"
                 v-if="reception"
                 id="invite-citizen-button">Invite</b-button>
       <b-button v-bind:class="serveNowStyle"
@@ -31,11 +31,11 @@
       <b-button-group>
         <b-button class="btn-primary"
                   @click="addCitizen"
-                  :disabled="citizenInvited===true || performingAction || showAdmin"
+                  :disabled="citizenInvited || showTimeTrackingIcon || performingAction || showAdmin"
                   id="add-citizen-button">Add Citizen</b-button>
         <b-dropdown v-if="user.office.quick_list.length > 0"
           :variant="citizenInvited===true || performingAction || showAdmin ? '' : 'primary'"
-          :disabled="citizenInvited===true || performingAction || showAdmin" right>
+          :disabled="citizenInvited || showTimeTrackingIcon || performingAction || showAdmin" right>
             <b-dropdown-item v-for="item in user.office.quick_list"
                     :data-id="item.service_id"
                     :key="item.service_id"
@@ -48,11 +48,11 @@
       <b-button-group>
         <b-button class="btn-primary"
                   @click="clickBackOffice"
-                  :disabled="citizenInvited===true || performingAction || showAdmin"
+                  :disabled="citizenInvited || showTimeTrackingIcon || performingAction || showAdmin"
                   id="add-citizen-button">Back Office</b-button>
         <b-dropdown v-if="user.office.back_office_list.length > 0"
           :variant="citizenInvited===true || performingAction || showAdmin ? '' : 'primary'"
-          :disabled="citizenInvited===true || performingAction || showAdmin" right>
+          :disabled="citizenInvited || showTimeTrackingIcon || performingAction || showAdmin" right>
             <b-dropdown-item v-for="item in user.office.back_office_list"
                     :data-id="item.service_id"
                     :key="item.service_id"
@@ -83,6 +83,7 @@
         'showAdmin',
         'showGAScreenModal',
         'showServiceModal',
+        'showTimeTrackingIcon',
         'serveNowStyle',
         'user',
       ]),

--- a/frontend/src/serve-citizen/dash-hold-table.vue
+++ b/frontend/src/serve-citizen/dash-hold-table.vue
@@ -69,7 +69,7 @@ limitations under the License.*/
     },
 
     computed: {
-      ...mapState(['citizens', 'citizenInvited', 'performingAction', 'user']),
+      ...mapState(['citizens', 'citizenInvited', 'performingAction', 'showTimeTrackingIcon', 'user']),
       ...mapGetters([
         'on_hold_queue',
         'citizens_queue',
@@ -101,6 +101,10 @@ limitations under the License.*/
       },
 
       rowClicked(item, index) {
+        if (this.showTimeTrackingIcon) {
+          this.$store.commit('setMainAlert', 'You are already serving a citizen.  Click the Stopwatch to resume')
+          return null
+        }
         if (this.performingAction) {
           return null
         }

--- a/frontend/src/serve-citizen/dash-table.vue
+++ b/frontend/src/serve-citizen/dash-table.vue
@@ -68,7 +68,7 @@ limitations under the License.*/
       }
     },
     computed: {
-      ...mapState(['citizenInvited', 'serviceModalForm', 'performingAction', 'user']),
+      ...mapState(['citizenInvited', 'serviceModalForm', 'performingAction', 'showTimeTrackingIcon', 'user']),
       ...mapGetters(['citizens_queue', 'active_service_id', 'reception']),
       citizens() {
         return this.citizens_queue
@@ -94,6 +94,10 @@ limitations under the License.*/
         return date.toLocaleTimeString()
       },
       rowClicked(item, index) {
+        if (this.showTimeTrackingIcon) {
+          this.$store.commit('setMainAlert', 'You are already serving a citizen.  Click the Stopwatch to resume')
+          return null
+        }
         if (this.performingAction) {
           return null
         }

--- a/frontend/src/serve-citizen/dash.vue
+++ b/frontend/src/serve-citizen/dash.vue
@@ -94,6 +94,10 @@ import GAScreen from './../ga-screen/ga-screen'
       }
     },
     beforeRouteLeave(to, from, next) {
+      if (this.showTimeTrackingIcon) {
+        next()
+        return
+      }
       if (to.path === '/exams' || to.path === '/booking') {
         this.clickAddCitizen()
         next()
@@ -103,18 +107,19 @@ import GAScreen from './../ga-screen/ga-screen'
     computed: {
       ...mapGetters(['citizens_queue', 'on_hold_queue', 'reception']),
       ...mapState([
-        'isLoggedIn',
-        'showAddModal',
         'citizenInvited',
         'dismissCountDown',
         'examsTrackingIP',
+        'isLoggedIn',
         'performingAction',
-        'showAdmin',
-        'showGAScreenModal',
-        'showServiceModal',
         'serveNowStyle',
         'serviceBegun',
         'serviceModalForm',
+        'showAddModal',
+        'showAdmin',
+        'showGAScreenModal',
+        'showServiceModal',
+        'showTimeTrackingIcon',
         'toggleShowAdmin',
         'user',
         'userLoadingFail'

--- a/frontend/src/serve-citizen/serve-citizen-table.vue
+++ b/frontend/src/serve-citizen/serve-citizen-table.vue
@@ -56,6 +56,11 @@
         </b-table>
       </b-col>
     </b-row>
+    <div v-if="showTicketNotice"
+         style="background-color: #bee5eb;"
+         class="p-2 m-0 tr-container-div">
+      You don't have a ticket started at this time.  Click Begin to start one.
+    </div>
   </div>
 </template>
 
@@ -83,7 +88,13 @@ export default {
       'invited_service_reqs',
       'active_service',
       'active_index'
-    ])
+    ]),
+    showTicketNotice() {
+      if (this.$route.path !== '/queue' && !this.serviceModalForm.citizen_id) {
+        return true
+      }
+      return false
+    },
   },
 
   methods: {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -154,6 +154,7 @@ export const store = new Vuex.Store({
     showSelectInvigilatorModal: false,
     showServeCitizenSpinner: false,
     showServiceModal: false,
+    showTimeTrackingIcon: false,
     user: {
       counter_id: null,
       csr_id: null,
@@ -2547,5 +2548,7 @@ export const store = new Vuex.Store({
     toggleServeCitizenSpinner(state, payload) {
       state.showServeCitizenSpinner = payload
     },
+    
+    toggleTimeTrackingIcon: (state, payload) => state.showTimeTrackingIcon = payload,
   }
 })


### PR DESCRIPTION
Changed the Minimize Button of the Serve Citizen Modal to hide the modal (on the condition that the Service Begun button has been pressed.  If citizen is 'invited' only, will revert to previous collapse behaviour).

Added conditions to Dash Table, Hold Table, router Navigation Guard for automatic ticket creation in exams, and Dash Buttons, to prevent starting additional tickets with current ticket minimized.

Adjusted Simplified Add Service Modal to display the catagories option but default it to 'Exams' instead of hiding it and fixing it on Exams only.  Adjusted the Serve Citizen modal to allow creation of ticket from Outside the Q and display message indicating noa active ticket when there is none.