### PR TITLE
Phase 1 - Active Citizen Count

### DIFF
--- a/frontend/src/Login.vue
+++ b/frontend/src/Login.vue
@@ -24,7 +24,12 @@ limitations under the License.*/
 
     <div v-show="this.$store.state.isLoggedIn"
          style="display: flex; flex-direction: row; justify-content: space-between; align-items: center;">
-
+      <div>
+        <div v-if="!$route.meta.hideCitizenWaiting && citizenSBType"
+             class="citizen_waiting">
+          Citizens Waiting: {{ queueLength }}
+        </div>
+      </div>
       <div style="margin-right: 22px;margin-top: 9px;">
         <label id="break-switch">
           <input type="checkbox" v-model="break_toggle">
@@ -68,9 +73,14 @@ import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
       _.defer(this.initSessionStorage)
     },
     computed: {
-      ...mapState(['user', 'csr_states']),
-      ...mapGetters(['quick_trans_status', 'reception', 'receptionist_status']),
-      
+      ...mapState(['user',
+                   'csr_states'
+                  ]),
+      ...mapGetters(['quick_trans_status',
+                     'reception',
+                     'receptionist_status',
+                     'citizens_queue',
+                    ]),
       counter_selection: {
         get() {
           console.log(this.receptionist_status)
@@ -117,6 +127,17 @@ import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
             this.setCSRState(id)
             this.setUserCSRStateName(name)
             this.updateCSRState()
+        }
+      },
+      queueLength() {
+        return this.citizens_queue.length
+      },
+      citizenSBType() {
+        if(this.user.office.sb.sb_type === 'nocallonsmartboard'){
+          return true
+        }
+        else {
+          return false
         }
       },
     },
@@ -347,5 +368,12 @@ input:checked + .circle1 + .circle2 {
     text-align: center;
     color: white;
     font-size: 14px;
+}
+.citizen_waiting {
+  padding-top: 5px;
+  padding-right: 40px;
+  white-space: pre-wrap;
+  font-size: 1.25em;
+  color: white;
 }
 </style>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -47,41 +47,47 @@ export default new Router({
             default: Dash,
             buttons: ButtonsDash,
           },
+          meta: { hideCitizenWaiting: true },
         },
         {
           path: 'admin',
           components: {
             default: Admin,
-            buttons: ButtonsAdmin
-          }
+            buttons: ButtonsAdmin,
+          },
+          meta: { hideCitizenWaiting: true },
         },
         {
           path: 'exams',
           components: {
             default: Exams,
-            buttons: ButtonsExams
-          }
+            buttons: ButtonsExams,
+          },
+          meta: { hideCitizenWaiting: false },
         },
         {
           path: 'agenda',
           components: {
             default: Agenda,
             buttons: ButtonsAgenda,
-          }
+          },
+          meta: { hideCitizenWaiting: true },
         },
         {
           path: 'appointments',
           components: {
             default: Appointments,
             buttons: ButtonsAppointments,
-          }
+          },
+          meta: { hideCitizenWaiting: true },
         },
         {
           path: 'booking',
           components: {
             default: Calendar,
             buttons: ButtonsCalendar,
-          }
+          },
+          meta: { hideCitizenWaiting: false },
         },
       ]
     },


### PR DESCRIPTION
Clients required that the count of citizens waiting in queue be present on the page for users based on the following:
	- if the office was a reception office (smart board type: nocallonsmartboard)
	- if the route of the app is either 'exams' or 'bookings'

Based on this, logic from the Q route was re-used to display the citizen waiting count now in the application header.