### PR TITLE
Phase 1 - Multiple Appointment Bookings

### DIFF
--- a/frontend/src/appointments/appointments.vue
+++ b/frontend/src/appointments/appointments.vue
@@ -59,7 +59,7 @@
         clickedAppt: null,
         clickedTime: null,
         config: {
-          selectOverlap: false,
+          selectOverlap: true,
           columnHeaderFormat: 'ddd/D',
           selectAllow: () => {
             return true
@@ -68,6 +68,7 @@
           editable: false,
           eventRender: (evt, el, view) => {
             el.css('font-size', '.9rem')
+            el.css('max-width', '85%')
           },
           eventColor: 'pink',
           eventConstraint: {


### PR DESCRIPTION
This PR addresses client feedback where only one appointment was allowed to be scheduled per given timeslot available in an office. The appointments calendar effectively works like the bookings calendar now, with the calendar background behind a scheduled event being made clickable now. Initial width of a given event in the column is 85% of it's max-width, but after a second event is scheduled, the remaining clickable column width returns to 5%.