### PR TITLE
Phase 1 - Non Exam Booking Contact Information

### DIFF
--- a/frontend/src/booking/other-booking-modal.vue
+++ b/frontend/src/booking/other-booking-modal.vue
@@ -220,6 +220,7 @@
           }
           this.postBooking(booking).then( () => {
             this.finishBooking()
+            this.contact_information = ''
           })
         } else {
           this.message = ' (Required)'


### PR DESCRIPTION
Clients noted that when booking multiple back-to-back non-exam events in the bookings calendar, that the contact information from the previous booking would carry forward.

This bug was resolved by setting the contact information variable for the other booking to modal to be an empty string after the POST has completed.