### PR TITLE
Phase 1 - Pesticide Exam Candidate Name

### DIFF
--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -151,7 +151,7 @@
           </b-col>
         </b-form-row>
 
-        <b-form-row v-if="examType === 'individual' || examType === 'other'">
+        <b-form-row v-if="examType === 'individual' || examType === 'other' || examType === 'pest'" >
           <b-col>
             <b-form-group>
               <label class="my-0">Candidate's Name</label>


### PR DESCRIPTION
Clients noticed that ITA Liaison users were unable to edit candidate names for pesticide exams. The logic that controlled this field on the edit exam for did not include the pesticide exam type, and was edited to include this exam type.