### PR TITLE
Phase 1 - Group/Pesticide Exam Office Validation

### DIFF
--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -248,8 +248,6 @@
             let { office_id, office_number } = this.user.office
             office_id = parseInt(office_id)
             office_number = parseInt(office_number)
-            this.captureExamDetail({ key: 'office_id', value: office_id })
-            this.setAddExamModalSetting({ office_number })
             return
           case 'other':
             this.resetModal()


### PR DESCRIPTION
Client noticed that when Group exams were created in series, the Office Name/Number fields were pre populated with the previous created exams value, instead of being blank. Also, validation of the field was already happening if the field was blank, which was definitely a bug. This bug was resolved by removing the office_id value being set on initialization of the add exam modal for group and pesticide exams.